### PR TITLE
Update vault CLI to 1.12.1

### DIFF
--- a/provisioning/vars/tooling_version.yml
+++ b/provisioning/vars/tooling_version.yml
@@ -1,7 +1,7 @@
 tooling:
   version:
     terraform: "1.3.5"
-    vault: "1.9.2"
+    vault: "1.12.1"
     packer: "1.8.2"
     nomad: "0.10.2"
     # renovate: datasource=github-releases depName=gruntwork-io/terragrunt


### PR DESCRIPTION
Reason: old version was marked as maleware under MacOS