### PR TITLE
20240917 modern yarn

### DIFF
--- a/provisioning/tasks/install/general/nvm.yml
+++ b/provisioning/tasks/install/general/nvm.yml
@@ -8,16 +8,27 @@
   shell: |
     . {{ ansible_env.HOME }}/.nvm/nvm.sh
     nvm install {{ item }}
-  loop: "{{ tooling.version.node.installed }}"
+  loop: "{{ tooling.version.node.modern + tooling.version.node.legacy }}"
   args:
     executable: /bin/bash
 
-- name: Install yarn for every node versions
+- name: Install yarn for legacy node versions
   shell: |
     . {{ ansible_env.HOME }}/.nvm/nvm.sh
     nvm use {{ item }}
     npm install --global yarn
-  loop: "{{ tooling.version.node.installed }}"
+  loop: "{{ tooling.version.node.legacy }}"
+  args:
+    executable: /bin/bash
+
+- name: Install latest yarn for modern node versions
+  shell: |
+    . {{ ansible_env.HOME }}/.nvm/nvm.sh
+    nvm use {{ item }}
+    npm uninstall -g yarn
+    corepack enable
+    corepack install -g yarn@latest
+  loop: "{{ tooling.version.node.modern }}"
   args:
     executable: /bin/bash
 
@@ -26,14 +37,5 @@
     . {{ ansible_env.HOME }}/.nvm/nvm.sh
     nvm alias default {{ tooling.version.node.default }}
     nvm use {{ tooling.version.node.default }}
-  args:
-    executable: /bin/bash
-
-- name: Set latest yarn for current node version
-  shell: |
-    . {{ ansible_env.HOME }}/.nvm/nvm.sh
-    npm uninstall -g yarn
-    corepack enable
-    corepack install -g yarn@latest
   args:
     executable: /bin/bash

--- a/provisioning/tasks/install/general/nvm.yml
+++ b/provisioning/tasks/install/general/nvm.yml
@@ -28,3 +28,12 @@
     nvm use {{ tooling.version.node.default }}
   args:
     executable: /bin/bash
+
+- name: Set latest yarn for current node version
+  shell: |
+    . {{ ansible_env.HOME }}/.nvm/nvm.sh
+    npm uninstall -g yarn
+    corepack enable
+    corepack install -g yarn@latest
+  args:
+    executable: /bin/bash

--- a/provisioning/vars/tooling_version.yml
+++ b/provisioning/vars/tooling_version.yml
@@ -38,8 +38,9 @@ tooling:
     task: "v3.38.0"
     node:
       default: "lts/iron"
-      installed:
-      - "lts/gallium" # 16.x
+      modern:
       - "lts/iron" # 20.x
+      legacy:
+      - "lts/gallium" # 16.x
     erlang: "26.2"
     elixir: "1.16.1-otp-26"


### PR DESCRIPTION
with https://github.com/modell-aachen/QwikiContrib/pull/7409 QwikiContrib uses yarn 4. This PR updates local tooling accordingly and requires `machine provision tooling` after merging.