### PR TITLE
Fix random error because of module install order

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -19,7 +19,7 @@
     all_remove_packages_darwin: |
       {{ dev.remove_packages_darwin | union(remove_packages_darwin) }}
     all_dev_install_modules: |
-      {{ dev.install_modules | union(install_modules) }}
+      {{ dev.install_modules + install_modules }}
     all_service_install_modules: |
       {{ service.install_modules | union(install_modules) }}
     all_kubectl_plugins: |

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -21,7 +21,7 @@
     all_dev_install_modules: |
       {{ dev.install_modules + install_modules }}
     all_service_install_modules: |
-      {{ service.install_modules | union(install_modules) }}
+      {{ service.install_modules + install_modules }}
     all_kubectl_plugins: |
       {{ dev.kubectl_plugins | union(kubectl_plugins) }}
     all_pip_packages: |


### PR DESCRIPTION
This makes the order in which modules are installed deterministic. As some modules depend on other modules to be installed first (e. g. certificates needs mkcert) we need a fixed order.