### PR TITLE
Add CI check for plugin.json machine hash

### DIFF
--- a/.github/workflows/check-plugin-hash.yml
+++ b/.github/workflows/check-plugin-hash.yml
@@ -1,0 +1,33 @@
+name: Check plugin.json machine hash
+
+on:
+  pull_request:
+    paths:
+      - "nixpkgs/modac-dev-machine/**"
+
+jobs:
+  check-hash:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify plugin.json rev matches HEAD
+        run: |
+          PLUGIN_JSON="devbox/plugins/modac/plugin.json"
+          CURRENT_HASH=$(grep -oP '(?<=&rev=)[a-f0-9]+' "$PLUGIN_JSON")
+          HEAD_HASH=$(git rev-parse HEAD)
+
+          if [ "$CURRENT_HASH" != "$HEAD_HASH" ]; then
+            echo "::error::plugin.json rev hash ($CURRENT_HASH) does not match HEAD ($HEAD_HASH)."
+            echo ""
+            echo "When changing files under nixpkgs/modac-dev-machine/, you must also"
+            echo "update the rev hash in plugin.json. Run:"
+            echo ""
+            echo "  /update-machine-hash   (in Claude Code)"
+            echo "  # or manually update the rev= in devbox/plugins/modac/plugin.json"
+            exit 1
+          fi
+
+          echo "plugin.json rev hash is up to date ($CURRENT_HASH)"


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that runs on PRs touching `nixpkgs/modac-dev-machine/`
- Fails if `plugin.json` rev hash doesn't match HEAD, preventing the issue where template changes (like the Mixpanel credential) don't reach users because the hash wasn't bumped

## Test plan
- [ ] Open a PR that changes a file under `nixpkgs/modac-dev-machine/` without updating the hash — CI should fail
- [ ] Update the hash and push — CI should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)