### PR TITLE
Update machine hash to include Mixpanel credential

### DIFF
--- a/devbox/plugins/modac/plugin.json
+++ b/devbox/plugins/modac/plugin.json
@@ -91,7 +91,7 @@
         "yq-go": {
             "version": "latest"
         },
-        "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=a9ec0598a9bf65ec4b5979a9c705ba7df19f2cd1": {}
+        "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=62d74dd1beb28395e4ac9781bd29338b561e2d36": {}
     },
     "env": {
         "DEVBOX_COREPACK_ENABLED": "true",


### PR DESCRIPTION
## Summary
- Updates the pinned rev hash in `plugin.json` to include the Mixpanel credential added in e88a32a
- Without this, `refresh-global` pulls the latest plugin but the machine binary still uses old templates missing `MIXPANEL_CLAUDE_EVENTS_TOKEN`

## Test plan
- [ ] Run `refresh-global` and verify `~/.secrets/env.tpl` contains `MIXPANEL_CLAUDE_EVENTS_TOKEN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)