### PR TITLE
Replace kubectx/kubens with kubie

### DIFF
--- a/devbox/plugins/modac/plugin.json
+++ b/devbox/plugins/modac/plugin.json
@@ -61,6 +61,9 @@
         "kubernetes-helm": {
             "version": "latest"
         },
+        "kubie": {
+            "version": "latest"
+        },
         "kustomize_4": {
             "version": "latest"
         },

--- a/nixpkgs/modac-dev-machine/cmd/machine/aliases.go
+++ b/nixpkgs/modac-dev-machine/cmd/machine/aliases.go
@@ -52,6 +52,18 @@ complete -F _qlone-completion qlone
 
 alias k='kubectl'
 complete -o default -F __start_kubectl k
+
+alias kctx='kubie ctx'
+alias kns='kubie ns'
+
+# kubie-only: current-context in ~/.kube/config entfernen, damit kubectl
+# ausserhalb einer kubie-Subshell keinen impliziten Context hat.
+# Nur wenn KUBECONFIG leer ist (sonst wuerden wir die temp-Config von kubie zerschiessen).
+if [ -z "$KUBECONFIG" ] && [ -f "$HOME/.kube/config" ] && command -v kubectl >/dev/null; then
+    if kubectl --kubeconfig="$HOME/.kube/config" config current-context >/dev/null 2>&1; then
+        kubectl --kubeconfig="$HOME/.kube/config" config unset current-context >/dev/null
+    fi
+fi
 `
 
 var aliasesCmd = &cobra.Command{

--- a/nixpkgs/modac-dev-machine/internal/provision/completions/completions.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/completions/completions.go
@@ -30,6 +30,7 @@ func Run(out *output.Context, plat platform.Platform) error {
 		{"op", "2_30_3"},
 		{"helm", "3_17_3"},
 		{"kubectl", "1_32_3"},
+		{"kubie", "0_25_4"},
 	}
 
 	for _, shell := range shells {

--- a/nixpkgs/modac-dev-machine/internal/provision/kubectlkrew/kubectlkrew.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/kubectlkrew/kubectlkrew.go
@@ -10,7 +10,15 @@ import (
 // Run installs kubectl krew plugins
 func Run(out *output.Context, plat platform.Platform) error {
 	_ = plat
-	plugins := []string{"ctx", "ns", "konfig", "oidc-login"}
+	plugins := []string{"konfig", "oidc-login"}
+
+	// Remove plugins that have been replaced by other tools (e.g. ctx/ns -> kubie).
+	// Errors are tolerated because the plugin may not be installed on fresh machines.
+	obsolete := []string{"ctx", "ns"}
+	for _, plugin := range obsolete {
+		out.Step(fmt.Sprintf("Removing obsolete krew plugin: %s", plugin))
+		_ = out.RunCommand("krew", "uninstall", plugin)
+	}
 
 	for _, plugin := range plugins {
 		out.Step(fmt.Sprintf("Installing krew plugin: %s", plugin))


### PR DESCRIPTION
## Summary
Ersetzt die Krew-Plugins `ctx` und `ns` durch `kubie`, da kubie context-basiert via Subshells arbeitet und so saubere Isolation pro Shell ermoeglicht.

## Aenderungen
- `kubie` als devbox-Paket aufgenommen (`devbox/plugins/modac/plugin.json`).
- `ctx` und `ns` aus der Krew-Plugin-Liste entfernt; Cleanup-Schritt `krew uninstall ctx ns` mit Fehlertoleranz fuer bereits provisionierte Maschinen vorangestellt (`kubectlkrew.go`). `konfig` und `oidc-login` bleiben.
- Shell-Completions fuer kubie ergaenzt (`completions.go`); landen via devbox-init-hook automatisch in der Shell.
- Aliase `kctx='kubie ctx'` und `kns='kubie ns'` plus Guard, der `current-context` aus `~/.kube/config` entfernt, sobald `KUBECONFIG` leer ist (verhindert impliziten Context ausserhalb von kubie-Subshells) – `aliases.go`.

## Follow-up
Nach dem Merge `machine update-machine-hash` ausfuehren, damit die `rev`-Hash in `plugin.json` auf den neuen Commit zeigt.