### PR TITLE
Fix kubie subshell on bash-minimal Nix profile

### DIFF
--- a/devbox/plugins/modac/plugin.json
+++ b/devbox/plugins/modac/plugin.json
@@ -97,7 +97,7 @@
         "yq-go": {
             "version": "latest"
         },
-        "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=01c54dd0df333729997b4d16d4fb454b612aa5e0": {}
+        "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=54b70afa2ee209c8ced32c483f2aea2aed1bbbcc": {}
     },
     "env": {
         "DEVBOX_COREPACK_ENABLED": "true",

--- a/devbox/plugins/modac/plugin.json
+++ b/devbox/plugins/modac/plugin.json
@@ -8,6 +8,9 @@
         "asdf-vm": {
             "version": "latest"
         },
+        "bashInteractive": {
+            "version": "latest"
+        },
         "github:sadjow/claude-code-nix/v2.1.145#claude-code": {},
         "crane": {
             "version": "latest"

--- a/nixpkgs/modac-dev-machine/internal/provision/completions/completions.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/completions/completions.go
@@ -12,8 +12,9 @@ import (
 )
 
 type completion struct {
-	cmd     string
-	version string
+	cmd        string
+	version    string
+	subcommand string
 }
 
 // Run installs shell completions for various tools
@@ -26,16 +27,16 @@ func Run(out *output.Context, plat platform.Platform) error {
 
 	shells := []string{"bash", "zsh"}
 	completions := []completion{
-		{"flux", "2_5_1"},
-		{"op", "2_30_3"},
-		{"helm", "3_17_3"},
-		{"kubectl", "1_32_3"},
-		{"kubie", "0_25_4"},
+		{"flux", "2_5_1", "completion"},
+		{"op", "2_30_3", "completion"},
+		{"helm", "3_17_3", "completion"},
+		{"kubectl", "1_32_3", "completion"},
+		{"kubie", "0_25_4", "generate-completion"},
 	}
 
 	for _, shell := range shells {
 		for _, comp := range completions {
-			if err := installCompletion(out, homeDir, shell, comp.cmd, comp.version); err != nil {
+			if err := installCompletion(out, homeDir, shell, comp.cmd, comp.version, comp.subcommand); err != nil {
 				// Log error but continue with other completions
 				out.Info(fmt.Sprintf("Warning: failed to install %s completion for %s: %v", comp.cmd, shell, err))
 			}
@@ -45,7 +46,7 @@ func Run(out *output.Context, plat platform.Platform) error {
 	return nil
 }
 
-func installCompletion(out *output.Context, homeDir, shell, cmd, version string) error {
+func installCompletion(out *output.Context, homeDir, shell, cmd, version, subcommand string) error {
 	shellPath := filepath.Join(homeDir, fmt.Sprintf(".%src", shell))
 	completionsPath := filepath.Join(homeDir, fmt.Sprintf(".%s_completions", shell))
 	cmdCompletionPath := filepath.Join(completionsPath, fmt.Sprintf("%s_%s.sh", cmd, version))
@@ -76,7 +77,7 @@ func installCompletion(out *output.Context, homeDir, shell, cmd, version string)
 
 	// Generate completion
 	out.Step(fmt.Sprintf("Installing %s completion for %s", cmd, shell))
-	completionCmd := exec.Command(cmd, "completion", shell)
+	completionCmd := exec.Command(cmd, subcommand, shell)
 	completionOutput, err := completionCmd.Output()
 	if err != nil {
 		return fmt.Errorf("failed to generate completion: %w", err)


### PR DESCRIPTION
## Problem

After the kubie update, `kctx` / `kns` broke the shell on at least one teammate's machine:

```
$ kctx
bash: shopt: progcomp: invalid shell option name
complete: command not found
... (many times)
bash: shopt: hostcomplete: invalid shell option name
...
[\[\]modac-local\[\]|\[\]qwiki-deployments\[\]] \[\]\[\]andreasmergl@andi-tuxedo\[\]:\[\]~/qwiki-repos/QwikiContrib\[\]$
```

Arrow keys emit raw escape sequences, `\[ \]` PS1 markers show up literally.

## Root cause

Kubie spawns its subshell with `Command::new("bash")` — a bare PATH lookup, no absolute path, no `$SHELL`. On affected machines `which bash` resolved to `/nix/store/...-bash-5.3p9/bin/bash`, i.e. **`bash-minimal`** — Nixpkgs builds it without `--enable-progcomp` and without readline, which is exactly the symptom set above.

This is not a kubie regression (`src/shell/bash.rs` hasn't changed since 2023). The kubie package update just refreshed the closure and `bash-minimal` ended up first on PATH.

## Fix

1. Add `bashInteractive` to the devbox plugin so a full bash (programmable completion + readline) is always first on PATH inside the devbox shell. Kubie's PATH-based `bash` lookup then picks the right binary.
2. Fix the kubie completion install: the subcommand is `generate-completion`, not `completion`. The previous call silently failed (logged as warning, no file written). Generalized the completion struct so each tool can declare its own subcommand.

## Verification

- `go vet ./...` and `go build ./...` clean.
- Reproduced the symptom mapping against kubie source and Nixpkgs bash-minimal build flags.
- Affected teammate confirmed `which bash` → `/nix/store/...-bash-5.3p9/bin/bash` (no `-interactive` suffix).