### PR TITLE
Force devbox profile bin to front of PATH for kubie calls

### DIFF
--- a/devbox/plugins/modac/plugin.json
+++ b/devbox/plugins/modac/plugin.json
@@ -97,7 +97,7 @@
         "yq-go": {
             "version": "latest"
         },
-        "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=54b70afa2ee209c8ced32c483f2aea2aed1bbbcc": {}
+        "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=8e2d74e521d52fca3076892a399cdf73837a59e0": {}
     },
     "env": {
         "DEVBOX_COREPACK_ENABLED": "true",

--- a/nixpkgs/modac-dev-machine/cmd/machine/aliases.go
+++ b/nixpkgs/modac-dev-machine/cmd/machine/aliases.go
@@ -53,8 +53,17 @@ complete -F _qlone-completion qlone
 alias k='kubectl'
 complete -o default -F __start_kubectl k
 
-alias kctx='kubie ctx'
-alias kns='kubie ns'
+# Kubie spawnt seine Subshell ueber bare 'bash' PATH-Lookup. Wenn irgendwo
+# ein bash-minimal (kein progcomp, keine readline) vor dem devbox-Profil im
+# PATH liegt, ist die Subshell unbrauchbar (shopt/complete-Fehler, keine
+# Pfeiltasten). Wir ziehen das devbox-Profil-bin gezielt fuer den kubie-Call
+# nach vorne, damit unsere bashInteractive zuerst gefunden wird.
+__modac_kubie() {
+    local devbox_bin="$HOME/.local/share/devbox/global/default/.devbox/nix/profile/default/bin"
+    PATH="$devbox_bin:$PATH" command kubie "$@"
+}
+kctx() { __modac_kubie ctx "$@"; }
+kns()  { __modac_kubie ns  "$@"; }
 
 # kubie-only: current-context in ~/.kube/config entfernen, damit kubectl
 # ausserhalb einer kubie-Subshell keinen impliziten Context hat.


### PR DESCRIPTION
## Problem (Follow-up zu #314)

PR #314 hat `bashInteractive` ins devbox-Profil installiert. Auf Andis Maschine half das nicht — `kctx` zeigte weiterhin `shopt: progcomp: invalid shell option name`, `complete: command not found`, literale `\[ \]` im Prompt, kaputte Pfeiltasten.

## Root cause (tiefer als gedacht)

1. Das `kubie`-Binary im devbox-Profil ist ein **Shell-Wrapper** mit Shebang auf bash-minimal:
   ```bash
   #! /nix/store/...-bash-5.3p9/bin/bash -e
   PATH='/nix/store/...kubectl-1.36.1/bin'$PATH
   exec ... "/nix/store/.../.kubie-wrapped" "$@"
   ```
2. Der Wrapper fuegt nur kubectl ins PATH ein, **nicht** bashInteractive.
3. Wenn der Aufrufer-Shell-PATH irgendwo ein bash-minimal-Storepath vor dem devbox-Profil-bin enthaelt, findet das echte kubie-Binary (Rust, `Command::new("bash")`) genau diese bash-minimal — egal was wir ins Profil installieren.
4. Auf Mac maskiert Homebrew das Problem (Homebrew-Bash steht frueher im PATH und ist eine volle Bash). Auf Ubuntu ohne Homebrew tritt es offen zutage.

## Fix

`kctx`/`kns` sind jetzt Shell-Funktionen, die das devbox-Profil-bin gezielt fuer den kubie-Aufruf ans PATH-Front schieben:

```bash
__modac_kubie() {
    local devbox_bin="$HOME/.local/share/devbox/global/default/.devbox/nix/profile/default/bin"
    PATH="$devbox_bin:$PATH" command kubie "$@"
}
kctx() { __modac_kubie ctx "$@"; }
kns()  { __modac_kubie ns  "$@"; }
```

Die Subshell, die kubie spawnt, erbt das modifizierte PATH — alle Folgeprozesse finden ebenfalls die bashInteractive zuerst.

## Verification

Lokal reproduziert mit kuenstlich vorgezogenem bash-minimal:
```
$ export PATH="/nix/store/...-bash-5.3p9/bin:$PATH"
$ which bash
/nix/store/...-bash-5.3p9/bin/bash          # broken
$ __modac_kubie exec orbstack default which bash
~/.local/share/devbox/.../profile/default/bin/bash   # fixed: findet bashInteractive
```

Syntax in bash + zsh OK (`bash -n` / `zsh -n` clean). `go vet ./...` und `go build ./...` clean.