### PR TITLE
Add tab completion for kctx/kns

### DIFF
--- a/devbox/plugins/modac/plugin.json
+++ b/devbox/plugins/modac/plugin.json
@@ -97,7 +97,7 @@
         "yq-go": {
             "version": "latest"
         },
-        "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=8e2d74e521d52fca3076892a399cdf73837a59e0": {}
+        "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=fc448a47522982c67b82983e5d307b3b711dd123": {}
     },
     "env": {
         "DEVBOX_COREPACK_ENABLED": "true",

--- a/devbox/plugins/modac/plugin.json
+++ b/devbox/plugins/modac/plugin.json
@@ -97,7 +97,7 @@
         "yq-go": {
             "version": "latest"
         },
-        "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=57f741b0e9dd2a0c2794e4f0395386ccd69945fb": {}
+        "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=15ec6607e23d031b2b2310b069849bb922ad1d24": {}
     },
     "env": {
         "DEVBOX_COREPACK_ENABLED": "true",

--- a/devbox/plugins/modac/plugin.json
+++ b/devbox/plugins/modac/plugin.json
@@ -97,7 +97,7 @@
         "yq-go": {
             "version": "latest"
         },
-        "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=fc448a47522982c67b82983e5d307b3b711dd123": {}
+        "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=57f741b0e9dd2a0c2794e4f0395386ccd69945fb": {}
     },
     "env": {
         "DEVBOX_COREPACK_ENABLED": "true",

--- a/nixpkgs/modac-dev-machine/cmd/machine/aliases.go
+++ b/nixpkgs/modac-dev-machine/cmd/machine/aliases.go
@@ -65,6 +65,37 @@ __modac_kubie() {
 kctx() { __modac_kubie ctx "$@"; }
 kns()  { __modac_kubie ns  "$@"; }
 
+# Completion fuer kctx/kns. Quelle ist 'kubectl config get-contexts -o name'
+# bzw. 'kubectl get namespaces -o name' — bewusst kubectl-basiert statt
+# kubies _kubie aufzurufen, damit es ohne compinit-Reihenfolge-Magie und
+# in bash wie zsh identisch funktioniert.
+if [ -n "$ZSH_VERSION" ]; then
+    _modac_kctx_zsh() {
+        local -a items
+        items=(${(f)"$(kubectl config get-contexts -o name 2>/dev/null)"})
+        _describe -t contexts 'kube context' items
+    }
+    _modac_kns_zsh() {
+        local -a items
+        items=(${(f)"$(kubectl get namespaces -o name 2>/dev/null | sed 's|^namespace/||')"})
+        _describe -t namespaces 'kube namespace' items
+    }
+    (( $+functions[compdef] )) || { autoload -Uz compinit && compinit -u 2>/dev/null; }
+    compdef _modac_kctx_zsh kctx
+    compdef _modac_kns_zsh kns
+elif [ -n "$BASH_VERSION" ]; then
+    _modac_kctx_bash() {
+        local cur="${COMP_WORDS[COMP_CWORD]}"
+        COMPREPLY=( $(compgen -W "$(kubectl config get-contexts -o name 2>/dev/null)" -- "$cur") )
+    }
+    _modac_kns_bash() {
+        local cur="${COMP_WORDS[COMP_CWORD]}"
+        COMPREPLY=( $(compgen -W "$(kubectl get namespaces -o name 2>/dev/null | sed 's|^namespace/||')" -- "$cur") )
+    }
+    complete -F _modac_kctx_bash kctx
+    complete -F _modac_kns_bash kns
+fi
+
 # kubie-only: current-context in ~/.kube/config entfernen, damit kubectl
 # ausserhalb einer kubie-Subshell keinen impliziten Context hat.
 # Nur wenn KUBECONFIG leer ist (sonst wuerden wir die temp-Config von kubie zerschiessen).

--- a/nixpkgs/modac-dev-machine/cmd/machine/aliases.go
+++ b/nixpkgs/modac-dev-machine/cmd/machine/aliases.go
@@ -90,9 +90,14 @@ if [ -n "$ZSH_VERSION" ]; then
         local expl
         _wanted namespaces expl 'kube namespace' compadd -a items
     }
-    (( $+functions[compdef] )) || { autoload -Uz compinit && compinit -u 2>/dev/null; }
-    compdef _modac_kctx_zsh kctx
-    compdef _modac_kns_zsh kns
+    # compdef wird von compinit definiert (im .zshrc des Users). Falls compinit
+    # noch nicht gelaufen ist, ueberspringen wir die Registrierung still — kein
+    # eigener compinit-Aufruf, weil wir sonst Insecure-fpath-Warnungen wegwerfen
+    # wuerden, die der User sehen sollte.
+    if (( $+functions[compdef] )); then
+        compdef _modac_kctx_zsh kctx
+        compdef _modac_kns_zsh kns
+    fi
 elif [ -n "$BASH_VERSION" ]; then
     _modac_kctx_bash() {
         local cur="${COMP_WORDS[COMP_CWORD]}"

--- a/nixpkgs/modac-dev-machine/cmd/machine/aliases.go
+++ b/nixpkgs/modac-dev-machine/cmd/machine/aliases.go
@@ -73,12 +73,22 @@ if [ -n "$ZSH_VERSION" ]; then
     _modac_kctx_zsh() {
         local -a items
         items=(${(f)"$(kubectl config get-contexts -o name 2>/dev/null)"})
-        _describe -t contexts 'kube context' items
+        if (( ${#items} == 0 )); then
+            _message 'no kube contexts'
+            return 1
+        fi
+        local expl
+        _wanted contexts expl 'kube context' compadd -a items
     }
     _modac_kns_zsh() {
         local -a items
         items=(${(f)"$(kubectl get namespaces -o name 2>/dev/null | sed 's|^namespace/||')"})
-        _describe -t namespaces 'kube namespace' items
+        if (( ${#items} == 0 )); then
+            _message 'no namespaces — enter a kubie context first (kctx)'
+            return 1
+        fi
+        local expl
+        _wanted namespaces expl 'kube namespace' compadd -a items
     }
     (( $+functions[compdef] )) || { autoload -Uz compinit && compinit -u 2>/dev/null; }
     compdef _modac_kctx_zsh kctx


### PR DESCRIPTION
## Problem

Seit #316 sind `kctx`/`kns` zsh/bash-Funktionen statt Aliase (notwendig fuer das PATH-Prepend zur bashInteractive). Folge: `kctx <TAB>` zeigt nur Dateinamen, weil keine Completion registriert ist. Aliase haetten unter sehr spezifischer Konfiguration via bash alias-expansion noch was abgefangen — Funktionen nicht.

## Fix

Eigene Completion fuer beide Shells, basiert auf `kubectl config get-contexts -o name` bzw. `kubectl get namespaces -o name`.

```zsh
# zsh — _wanted suppress file-fallback, _message + return 1 fuer Empty-State
_modac_kctx_zsh() {
    local -a items
    items=(${(f)"$(kubectl config get-contexts -o name 2>/dev/null)"})
    if (( ${#items} == 0 )); then
        _message 'no kube contexts'
        return 1
    fi
    local expl
    _wanted contexts expl 'kube context' compadd -a items
}
if (( $+functions[compdef] )); then
    compdef _modac_kctx_zsh kctx
    compdef _modac_kns_zsh kns
fi
```

```bash
# bash
_modac_kctx_bash() {
    local cur="${COMP_WORDS[COMP_CWORD]}"
    COMPREPLY=( $(compgen -W "$(kubectl config get-contexts -o name 2>/dev/null)" -- "$cur") )
}
complete -F _modac_kctx_bash kctx
```

## Designentscheidungen

**Warum nicht kubies eigene Completion wrappen?**
Kubie nutzt `clap`-generierte Completion. Die kennt nur statische Werte — Flag-Namen, Subcommand-Namen — aber keine dynamischen wie Context-/Namespace-Namen zur Laufzeit.

- bash: `[CONTEXT_NAME]` wird als literaler Text vorgeschlagen
- zsh: `_default` fuer den Context-Wert → faellt auf File-Completion zurueck (genau der Bug, den wir hier fixen)

Empirisch verifiziert: `kctx orb<TAB>` mit Wrapper → leeres COMPREPLY. Mit unserer Variante → `orbstack`.

**Warum kein eigener compinit-Aufruf?**
`source <(machine aliases)` laeuft via devbox `init_hook` (plugin.json:118-120) nach dem `.zshrc` des Users — also nach dessen `compinit`. Wenn `compdef` trotzdem nicht existiert, hat der User ein Setup-Problem; wir maskieren das nicht mit `compinit -u 2>/dev/null`, sondern ueberspringen die Registrierung still.

**Warum `_wanted` statt `_describe`?**
`_wanted contexts expl 'kube context' compadd -a items` ist das kanonische zsh-Idiom fuer "eine Gruppe Kandidaten unter einem Tag, keine Descriptions". `_describe` haette auch funktioniert; der Empty-Path mit `_message` + `return 1` ist der eigentliche Punkt — verhindert, dass zsh stillschweigend auf File-Completion zurueckfaellt.

## Beispiel

| Eingabe | Vorher (PR #316) | Jetzt |
|---|---|---|
| `kctx <TAB>` | `CLAUDE.md  devbox/  install*  nixpkgs/` (Files) | Listet echte Contexts (orbstack, gcpeuw3-…, rxac01-…) |
| `kctx orb<TAB>` | nichts | `orbstack` |
| `kns <TAB>` (in kubie-Subshell) | Files | Listet Namespaces (default, kube-public, …) |
| `kns <TAB>` (ausserhalb) | Files | `no namespaces — enter a kubie context first (kctx)` |

## Verification

- `go vet`, `go build`, `bash -n`, `zsh -n` clean
- `_comps[kctx]` / `_comps[kns]` zeigt unsere Funktionen in zsh
- `complete -p kctx` / `complete -p kns` zeigt unsere Funktionen in bash
- End-to-end-Test bei Kollegen auf Ubuntu (zsh) und bei mir (Mac, zsh): TAB liefert echte Contexts/Namespaces, kein File-Fallback mehr