### PR TITLE
Fix orbstack status check on stopped state

### DIFF
--- a/nixpkgs/modac-dev-machine/internal/provision/orbstack/orbstack.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/orbstack/orbstack.go
@@ -23,15 +23,17 @@ func Run(out *output.Context, plat platform.Platform) error {
 }
 
 func runDarwin(out *output.Context) error {
-	// Check OrbStack status
+	// Check OrbStack status. orbctl exits non-zero when OrbStack is not
+	// running (e.g. "Stopped" returns exit status 1), so the status string
+	// is authoritative rather than the exit code.
 	statusCmd := exec.Command("orbctl", "status")
 	statusOutput, err := statusCmd.Output()
-	if err != nil {
+	status := string(bytes.TrimSpace(statusOutput))
+	if status == "" {
 		return fmt.Errorf("failed to check OrbStack status: %w", err)
 	}
 
-	status := string(bytes.TrimSpace(statusOutput))
-	if status == "Stopped" {
+	if status != "Running" {
 		// Start OrbStack
 		out.Step("Starting OrbStack")
 		if err := out.RunCommand("orbctl", "start"); err != nil {


### PR DESCRIPTION
## Problem

`machine provision` failed on the `orbstack` module with:

```
✗ Module failed: failed to check OrbStack status: exit status 1
```

`orbctl status` signals state through its **exit code**, not just stdout:

| State   | stdout    | exit code |
|---------|-----------|-----------|
| Running | `Running` | `0`       |
| Stopped | `Stopped` | `1`       |

The module used `cmd.Output()`, which returns a non-nil error on any non-zero exit. So when OrbStack was simply **stopped**, the code bailed at the `if err != nil` check before reading the `Stopped` string that should have triggered a start.

## Fix

The status string is now authoritative instead of the exit code:

- stdout is captured regardless of the exit code
- a hard error is only returned when there is **no** usable status output (genuine failure, e.g. `orbctl` missing)
- OrbStack is started whenever status is not `Running` (covers `Stopped` and transient non-running states)

`go build ./...` and `go vet` pass.