### PR TITLE
Use DOCKER_CONFIG env var for distrobox docker config

### DIFF
--- a/nixpkgs/modac-dev-machine/internal/provision/dockerpackages/dockerpackages.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/dockerpackages/dockerpackages.go
@@ -108,33 +108,33 @@ func runUbuntu(out *output.Context) error {
 	containerID := os.Getenv("CONTAINER_ID")
 	if containerID != "" {
 		// Check if docker command exists
-		_, err := exec.LookPath("docker")
-		if err != nil {
-			// Docker not found, create symlinks
+		if _, err := exec.LookPath("docker"); err != nil {
+			// Docker not found, link it to the host
 			out.Step("Running inside a distrobox, linking docker")
-
-			// Create symlink for docker
 			if err := out.RunCommand("sudo", "ln", "-s", "/usr/local/bin/distrobox-host-exec-with-env", "/usr/local/bin/docker"); err != nil {
 				return fmt.Errorf("failed to create docker symlink: %w", err)
-			}
-
-			// Link .docker directory
-			homeDir, err := os.UserHomeDir()
-			if err != nil {
-				return fmt.Errorf("failed to get home directory: %w", err)
-			}
-
-			user := os.Getenv("USER")
-			hostDockerDir := fmt.Sprintf("/run/host/home/%s/.docker", user)
-			localDockerDir := filepath.Join(homeDir, ".docker")
-
-			out.Step("Linking .docker directory")
-			if err := out.RunCommand("ln", "-s", hostDockerDir, localDockerDir); err != nil {
-				return fmt.Errorf("failed to link .docker directory: %w", err)
 			}
 		} else {
 			out.Skipped("Running inside a distrobox, docker already available")
 		}
+
+		// Point DOCKER_CONFIG at the host's .docker directory, independent of
+		// whether docker itself was just linked.
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("failed to get home directory: %w", err)
+		}
+
+		user := os.Getenv("USER")
+		hostDockerDir := fmt.Sprintf("/run/host/home/%s/.docker", user)
+		bashrcPath := filepath.Join(homeDir, ".bashrc")
+		exportLine := fmt.Sprintf("export DOCKER_CONFIG=%q", hostDockerDir)
+
+		out.Step("Setting DOCKER_CONFIG in .bashrc")
+		if err := appendLineIfMissing(bashrcPath, exportLine); err != nil {
+			return fmt.Errorf("failed to update .bashrc: %w", err)
+		}
+
 		return nil
 	}
 
@@ -225,6 +225,33 @@ func runUbuntu(out *output.Context) error {
 		return fmt.Errorf("logout required - please logout and login again")
 	}
 
+	return nil
+}
+
+// appendLineIfMissing appends line to the file at path (creating it if needed),
+// unless the line is already present. A trailing newline is ensured.
+func appendLineIfMissing(path, line string) error {
+	if util.FileExists(path) {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for _, existing := range strings.Split(string(content), "\n") {
+			if strings.TrimSpace(existing) == line {
+				return nil
+			}
+		}
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := fmt.Fprintf(f, "%s\n", line); err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
## What

Changes how Docker config is wired up inside a distrobox in the `dockerpackages` provisioning module.

- **Before:** symlinked `~/.docker` → `/run/host/home/$USER/.docker`.
- **After:** appends `export DOCKER_CONFIG="/run/host/home/$USER/.docker"` to `~/.bashrc`, pointing Docker at the host config folder without a symlink.

## Why

Avoids creating a symlink in the home directory; `DOCKER_CONFIG` is the supported mechanism for relocating Docker's config directory and is less intrusive.

## Notes

- The `DOCKER_CONFIG` setup now runs **independent of** the `docker`-command availability check. Previously it was nested under the "docker not found" branch, so a distrobox that already had `docker` on `PATH` would skip config setup entirely. The host-link of the `docker` binary remains conditional on that check.
- A small `appendLineIfMissing` helper keeps the `.bashrc` edit idempotent across re-runs of `machine provision`.
- `DOCKER_CONFIG` only takes effect in new shells after provisioning (the old symlink was active immediately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)