### PR TITLE
Update machine hash to 17de1c8

### DIFF
--- a/devbox/plugins/modac/plugin.json
+++ b/devbox/plugins/modac/plugin.json
@@ -117,7 +117,7 @@
         "yq-go": {
             "version": "latest"
         },
-        "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=55b1cb491aa79e8b37606916e0e7607c993c91b5": {}
+        "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=17de1c884da5dd19af786e95f6d9d131de3e0f52": {}
     },
     "env": {
         "DEVBOX_COREPACK_ENABLED": "true",


### PR DESCRIPTION
Updates the `plugin.json` rev hash to match the latest `main` commit (`17de1c8`, the DOCKER_CONFIG distrobox change in #344), so the global devbox config pulls the current plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)