### PR TITLE
Guard Homebrew PATH on systems without HOMEBREW_PREFIX

### DIFF
--- a/devbox/plugins/modac/plugin.json
+++ b/devbox/plugins/modac/plugin.json
@@ -131,10 +131,11 @@
         "ASDF_DATA_DIR": "$HOME/.asdf",
         "KREW_ROOT": "$HOME/.krew",
         "XDG_DATA_DIRS": "$HOME/.local/share/devbox/global/default/.devbox/nix/profile/default/share:$XDG_DATA_DIRS",
-        "PATH": "$HOME/.krew/bin:$HOME/.local/bin:$HOME/.asdf/shims:$HOME/.pyenv/bin:$HOMEBREW_PREFIX/bin:$HOMEBREW_PREFIX/opt/gnu-getopt/bin:$HOMEBREW_PREFIX/opt/gnu-sed/libexec/gnubin:$PATH"
+        "PATH": "$HOME/.krew/bin:$HOME/.local/bin:$HOME/.asdf/shims:$HOME/.pyenv/bin:$PATH"
     },
     "shell": {
         "init_hook": [
+            "[ -n \"$HOMEBREW_PREFIX\" ] && export PATH=\"$HOMEBREW_PREFIX/bin:$HOMEBREW_PREFIX/opt/gnu-getopt/bin:$HOMEBREW_PREFIX/opt/gnu-sed/libexec/gnubin:$PATH\"",
             "_DEVBOX_SHELL=bash; [ -n \"$ZSH_VERSION\" ] && _DEVBOX_SHELL=zsh; type complete &>/dev/null && source <(devbox completion $_DEVBOX_SHELL)",
             "_DEVBOX_SHELL=bash; [ -n \"$ZSH_VERSION\" ] && _DEVBOX_SHELL=zsh; eval \"$(direnv hook $_DEVBOX_SHELL)\"",
             "source <(machine aliases)",


### PR DESCRIPTION
## Problem

The plugin's `env.PATH` prepended `$HOMEBREW_PREFIX/bin`, `$HOMEBREW_PREFIX/opt/gnu-getopt/bin`, and `$HOMEBREW_PREFIX/opt/gnu-sed/libexec/gnubin`. On systems where `HOMEBREW_PREFIX` is not set (i.e. Linux, no Homebrew), devbox expands the unset variable to an empty string, collapsing these into `/bin`, `/opt/gnu-getopt/bin`, and `/opt/gnu-sed/libexec/gnubin` — incorrectly prepending `/bin` to `PATH`.

devbox's `env`-field expansion only does plain `$VAR`/`${VAR}` substitution and does not support bash default/conditional syntax (`${VAR:+...}`), so the guard can't live in the `env` block.

## Fix

- Removed the three `$HOMEBREW_PREFIX/...` segments from the static `env.PATH`.
- Added a guarded `init_hook` entry that only prepends the Homebrew paths when `$HOMEBREW_PREFIX` is set. These paths are macOS-only anyway, so they have no purpose on Linux.

## Note

The Homebrew paths now sit at the front of `PATH` (ahead of `~/.krew/bin` etc.) rather than after them, since the `init_hook` runs after the env block is applied. In the original they were already ahead of the nix profile, and brew's bin/gnu utils don't collide with the krew/asdf/pyenv shims, so this is harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)