### PR TITLE
Add nix-conf provisioning module

### DIFF
--- a/nixpkgs/modac-dev-machine/internal/provision/executor.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/executor.go
@@ -17,6 +17,7 @@ import (
 	"github.com/modell-aachen/machine/internal/provision/githubauthlogin"
 	"github.com/modell-aachen/machine/internal/provision/installmodacshellhelper"
 	"github.com/modell-aachen/machine/internal/provision/kubectlkrew"
+	"github.com/modell-aachen/machine/internal/provision/nixconf"
 	"github.com/modell-aachen/machine/internal/provision/node"
 	"github.com/modell-aachen/machine/internal/provision/nssdb"
 	"github.com/modell-aachen/machine/internal/provision/onepassword"
@@ -40,6 +41,7 @@ type ModuleEntry struct {
 
 // allModules defines the ordered list of all provisioning modules
 var allModules = []ModuleEntry{
+	{"nix-conf", nixconf.Run},
 	{"devbox-update", devboxupdate.Run},
 	{"onepassword", onepassword.Run},
 	{"restore-backup", restorebackup.Run},

--- a/nixpkgs/modac-dev-machine/internal/provision/nixconf/nixconf.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/nixconf/nixconf.go
@@ -1,0 +1,114 @@
+package nixconf
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/modell-aachen/machine/internal/output"
+	"github.com/modell-aachen/machine/internal/platform"
+	"github.com/modell-aachen/machine/internal/util"
+)
+
+const (
+	experimentalFeaturesKey  = "experimental-features"
+	experimentalFeaturesLine = "experimental-features = nix-command flakes"
+)
+
+// requiredFeatures are the features that must be enabled for flakes and the
+// modern nix CLI to work.
+var requiredFeatures = []string{"nix-command", "flakes"}
+
+// Run ensures ~/.config/nix/nix.conf enables the nix-command and flakes
+// experimental features.
+func Run(out *output.Context, plat platform.Platform) error {
+	_ = plat
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	confPath := filepath.Join(homeDir, ".config", "nix", "nix.conf")
+
+	if !util.FileExists(confPath) {
+		return createConf(out, confPath)
+	}
+
+	return updateConf(out, confPath)
+}
+
+func createConf(out *output.Context, confPath string) error {
+	if err := os.MkdirAll(filepath.Dir(confPath), 0755); err != nil {
+		return fmt.Errorf("failed to create nix config directory: %w", err)
+	}
+
+	out.Step("Creating nix.conf with experimental features")
+	content := experimentalFeaturesLine + "\n"
+	if err := os.WriteFile(confPath, []byte(content), 0644); err != nil {
+		return fmt.Errorf("failed to write nix.conf: %w", err)
+	}
+
+	return nil
+}
+
+func updateConf(out *output.Context, confPath string) error {
+	data, err := os.ReadFile(confPath)
+	if err != nil {
+		return fmt.Errorf("failed to read nix.conf: %w", err)
+	}
+
+	if hasRequiredFeatures(string(data)) {
+		out.Skipped("nix.conf already enables nix-command and flakes")
+		return nil
+	}
+
+	out.Step("Appending experimental features to nix.conf")
+	content := string(data)
+	if len(content) > 0 && !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+	content += experimentalFeaturesLine + "\n"
+
+	if err := os.WriteFile(confPath, []byte(content), 0644); err != nil {
+		return fmt.Errorf("failed to write nix.conf: %w", err)
+	}
+
+	return nil
+}
+
+// hasRequiredFeatures reports whether an existing experimental-features setting
+// already enables all required features.
+func hasRequiredFeatures(content string) bool {
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		key, value, found := strings.Cut(trimmed, "=")
+		if !found || strings.TrimSpace(key) != experimentalFeaturesKey {
+			continue
+		}
+
+		enabled := strings.Fields(value)
+		if containsAll(enabled, requiredFeatures) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func containsAll(haystack, needles []string) bool {
+	set := make(map[string]bool, len(haystack))
+	for _, h := range haystack {
+		set[h] = true
+	}
+	for _, n := range needles {
+		if !set[n] {
+			return false
+		}
+	}
+	return true
+}

--- a/nixpkgs/modac-dev-machine/internal/provision/nixconf/nixconf_test.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/nixconf/nixconf_test.go
@@ -1,0 +1,30 @@
+package nixconf
+
+import "testing"
+
+func TestHasRequiredFeatures(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{"empty file", "", false},
+		{"exact line", "experimental-features = nix-command flakes\n", true},
+		{"reordered features", "experimental-features = flakes nix-command\n", true},
+		{"extra features", "experimental-features = nix-command flakes ca-derivations\n", true},
+		{"no spaces around equals", "experimental-features=nix-command flakes\n", true},
+		{"only nix-command", "experimental-features = nix-command\n", false},
+		{"only flakes", "experimental-features = flakes\n", false},
+		{"unrelated key", "max-jobs = 4\n", false},
+		{"commented out", "# experimental-features = nix-command flakes\n", false},
+		{"set among other lines", "max-jobs = 4\nexperimental-features = nix-command flakes\nsandbox = true\n", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasRequiredFeatures(tt.content); got != tt.want {
+				t.Errorf("hasRequiredFeatures(%q) = %v, want %v", tt.content, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Adds a new `nix-conf` provisioning module that ensures `~/.config/nix/nix.conf` enables the `nix-command` and `flakes` experimental features. This replaces a manual step we currently have to do on every machine:

```
experimental-features = nix-command flakes
```

## Behavior

The module is idempotent:
- **Missing file** → creates `~/.config/nix/` and writes the setting.
- **File without the features** → appends the line (handles a missing trailing newline).
- **Features already enabled** → skips.

The detection is robust: it's order-independent (`flakes nix-command` works), tolerates extra features on the line (e.g. `ca-derivations`), handles `=` with or without surrounding spaces, and ignores commented-out lines.

## Ordering

Registered as the first module in `executor.go` so flakes / `nix-command` are enabled before later modules that may depend on them. Run in isolation with `machine provision -f nix-conf`.

## Tests

Added a table-driven test for the parsing/idempotency logic (`hasRequiredFeatures`) covering exact match, reordering, extra features, comments, partial matches, and multi-line configs.

## Verification

- `go build ./...` and `go vet ./...` pass
- `go test ./internal/provision/nixconf/` passes
- `machine provision list-modules` shows `nix-conf` at the top

## Note

This writes a per-user `nix.conf`, which is the right default for a dev machine. On a multi-user Nix daemon install the setting sometimes needs to live in `/etc/nix/nix.conf` instead — out of scope here, but worth flagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)