### PR TITLE
Update machine hash to 47851ed

### DIFF
--- a/devbox/plugins/modac/plugin.json
+++ b/devbox/plugins/modac/plugin.json
@@ -109,7 +109,7 @@
     "yq-go": {
       "version": "latest"
     },
-    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=17de1c884da5dd19af786e95f6d9d131de3e0f52": {}
+    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=47851ed2a51c4a9546dcfadb45c4d277d7c5a187": {}
   },
   "env": {
     "DEVBOX_COREPACK_ENABLED": "true",


### PR DESCRIPTION
Updates the pinned plugin rev in `devbox/plugins/modac/plugin.json` from `17de1c8` to `47851ed`, picking up the merged nix-conf provisioning module (#348).

🤖 Generated with [Claude Code](https://claude.com/claude-code)