### PR TITLE
feat: provide gke-gcloud-auth-plugin for GKE Workforce Identity

### DIFF
--- a/devbox/plugins/modac/plugin.json
+++ b/devbox/plugins/modac/plugin.json
@@ -45,7 +45,7 @@
     "go-task": {
       "version": "latest"
     },
-    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=47851ed2a51c4a9546dcfadb45c4d277d7c5a187#google-cloud-sdk-gke": {},
+    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=c75b338c124f874c255b587698156ff46dbb7f3d#google-cloud-sdk-gke": {},
     "htop": {
       "version": "latest"
     },
@@ -107,7 +107,7 @@
     "yq-go": {
       "version": "latest"
     },
-    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=47851ed2a51c4a9546dcfadb45c4d277d7c5a187": {}
+    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=c75b338c124f874c255b587698156ff46dbb7f3d": {}
   },
   "env": {
     "DEVBOX_COREPACK_ENABLED": "true",

--- a/devbox/plugins/modac/plugin.json
+++ b/devbox/plugins/modac/plugin.json
@@ -45,9 +45,7 @@
     "go-task": {
       "version": "latest"
     },
-    "google-cloud-sdk": {
-      "version": "latest"
-    },
+    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=47851ed2a51c4a9546dcfadb45c4d277d7c5a187#google-cloud-sdk-gke": {},
     "htop": {
       "version": "latest"
     },

--- a/nixpkgs/modac-dev-machine/flake.lock
+++ b/nixpkgs/modac-dev-machine/flake.lock
@@ -34,10 +34,27 @@
         "type": "github"
       }
     },
+    "nixpkgs-gcloud": {
+      "locked": {
+        "lastModified": 1777270315,
+        "narHash": "sha256-yKB4G6cKsQsWN7M6rZGk6gkJPDNPIzT05y4qzRyCDlI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6368eda62c9775c38ef7f714b2555a741c20c72d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6368eda62c9775c38ef7f714b2555a741c20c72d",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-gcloud": "nixpkgs-gcloud"
       }
     },
     "systems": {

--- a/nixpkgs/modac-dev-machine/flake.nix
+++ b/nixpkgs/modac-dev-machine/flake.nix
@@ -4,15 +4,26 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
     flake-utils.url = "github:numtide/flake-utils";
+    # Pinned to the same revision devbox resolves "google-cloud-sdk" to, so the
+    # gcloud CLI and the bundled gke-gcloud-auth-plugin stay on the same version.
+    nixpkgs-gcloud.url = "github:NixOS/nixpkgs/6368eda62c9775c38ef7f714b2555a741c20c72d";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs, flake-utils, nixpkgs-gcloud }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; };
+        pkgsGcloud = import nixpkgs-gcloud { inherit system; };
       in
       {
         packages = {
+          # google-cloud-sdk plus the gke-gcloud-auth-plugin component, which the
+          # base package omits. Required for kubectl auth against GKE clusters
+          # using Workforce Identity Federation.
+          google-cloud-sdk-gke = pkgsGcloud.google-cloud-sdk.withExtraComponents [
+            pkgsGcloud.google-cloud-sdk.components.gke-gcloud-auth-plugin
+          ];
+
           machine = pkgs.buildGoModule {
             pname = "machine";
             version = "1.0.0";


### PR DESCRIPTION
## Kontext

Identity Service for GKE wird zum **1. Juli 2026** abgeschaltet. Der Migrationspfad (Workforce Identity Federation) verlangt für `kubectl`-Auth gegen GKE das **gke-gcloud-auth-plugin**. Das nix-`google-cloud-sdk` enthält diese Komponente nicht — bislang lag sie nur zufällig über ein manuell installiertes Homebrew-gcloud auf dem PATH. Das Repo provisioniert sie damit aktuell **gar nicht**.

## Änderung

- **`flake.nix`**: neuer Output `google-cloud-sdk-gke` = `google-cloud-sdk.withExtraComponents [ … gke-gcloud-auth-plugin ]`, mit eigenem Input `nixpkgs-gcloud`, gepinnt auf dieselbe nixpkgs-Rev, auf die devbox `google-cloud-sdk` auflöst (gcloud + Plugin bleiben auf 565.0.0).
- **`flake.lock`**: Input `nixpkgs-gcloud` aufgenommen.
- **`plugin.json`**: `google-cloud-sdk` ersetzt durch die Flake-Ref auf `#google-cloud-sdk-gke`; beide Self-Refs auf den neuen Commit gepinnt.

Verifiziert: Output baut und enthält in `bin/` sowohl `gcloud` als auch `gke-gcloud-auth-plugin`; `machine`-Paket evaluiert weiterhin; `plugin.json` ist valides JSON.

## Hinweise

- `update-machine-hash.sh` nutzt GNU-`sed -i` und schlägt auf macOS (BSD sed) fehl — der rev-Bump in diesem PR wurde portabel von Hand gemacht. Ggf. das Skript separat fixen (`sed -i ''` bzw. perl).
- Nach Merge: globale `devbox.json` auf den neuen Plugin-Rev nachziehen, `devbox install`. Das manuell installierte Homebrew-gcloud sollte entfernt werden, damit das nix-gcloud nicht überschattet wird.