### PR TITLE
feat: add gcloud-workforce-login provisioning module

### DIFF
--- a/nixpkgs/modac-dev-machine/internal/provision/executor.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/executor.go
@@ -14,6 +14,7 @@ import (
 	"github.com/modell-aachen/machine/internal/provision/devboxupdate"
 	"github.com/modell-aachen/machine/internal/provision/docker"
 	"github.com/modell-aachen/machine/internal/provision/dockerpackages"
+	"github.com/modell-aachen/machine/internal/provision/gcloudworkforcelogin"
 	"github.com/modell-aachen/machine/internal/provision/githubauthlogin"
 	"github.com/modell-aachen/machine/internal/provision/installmodacshellhelper"
 	"github.com/modell-aachen/machine/internal/provision/kubectlkrew"
@@ -58,6 +59,7 @@ var allModules = []ModuleEntry{
 	{"completions", completions.Run},
 	{"claude", claude.Run},
 	{"github-auth-login", githubauthlogin.Run},
+	{"gcloud-workforce-login", gcloudworkforcelogin.Run},
 	{"install-modac-shell-helper", installmodacshellhelper.Run},
 	{"orbstack", orbstack.Run},
 	{"docker-packages", dockerpackages.Run},

--- a/nixpkgs/modac-dev-machine/internal/provision/gcloudworkforcelogin/gcloudworkforcelogin.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/gcloudworkforcelogin/gcloudworkforcelogin.go
@@ -1,0 +1,78 @@
+package gcloudworkforcelogin
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/modell-aachen/machine/internal/output"
+	"github.com/modell-aachen/machine/internal/platform"
+)
+
+// Workforce Identity Federation pool and provider that back GKE cluster
+// authentication. Identity Service for GKE is discontinued on 2026-07-01;
+// afterwards kubectl authenticates via gke-gcloud-auth-plugin, which obtains a
+// token from the active gcloud credential. This module makes that credential a
+// Workforce Identity (federated via Azure AD) instead of a Google account.
+const (
+	workforcePool     = "ariadne-workforce"
+	workforceProvider = "ariadne-workforce"
+)
+
+// Run configures gcloud for Workforce Identity Federation and signs the user
+// in, so that gke-gcloud-auth-plugin can obtain GKE tokens with no further
+// manual setup.
+func Run(out *output.Context, plat platform.Platform) error {
+	_ = plat
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to determine home directory: %w", err)
+	}
+	loginConfig := filepath.Join(home, ".config", "gcloud", "ariadne-login-config.json")
+
+	// 1. Generate the (non-secret) login config describing the workforce pool
+	//    provider, unless it already exists. This must succeed without an active
+	//    credential, since it is a prerequisite for signing in.
+	if _, statErr := os.Stat(loginConfig); statErr != nil {
+		out.Step("Generating Workforce Identity login config")
+		provider := fmt.Sprintf("locations/global/workforcePools/%s/providers/%s", workforcePool, workforceProvider)
+		genCmd := exec.Command("gcloud", "iam", "workforce-pools", "create-login-config",
+			provider, "--output-file="+loginConfig)
+		genCmd.Stdout = out.MultiWriter(nil)
+		genCmd.Stderr = out.MultiWriter(nil)
+		if err := genCmd.Run(); err != nil {
+			return fmt.Errorf("failed to create workforce login config: %w", err)
+		}
+	} else {
+		out.Skipped("Workforce login config already present")
+	}
+
+	// 2. Make gcloud use the workforce login config for browser sign-in, so a
+	//    plain `gcloud auth login` runs the Workforce (Azure AD) flow.
+	out.Step("Configuring gcloud to use the Workforce login config")
+	setCmd := exec.Command("gcloud", "config", "set", "auth/login_config_file", loginConfig)
+	setCmd.Stdout = out.MultiWriter(nil)
+	setCmd.Stderr = out.MultiWriter(nil)
+	if err := setCmd.Run(); err != nil {
+		return fmt.Errorf("failed to set gcloud login config: %w", err)
+	}
+
+	// 3. Sign in if there is no active credential yet (interactive browser flow).
+	if err := exec.Command("gcloud", "auth", "print-access-token").Run(); err == nil {
+		out.Skipped("gcloud already has an active credential")
+		return nil
+	}
+
+	out.Step("Logging into Google Cloud via Workforce Identity (interactive)")
+	loginCmd := exec.Command("gcloud", "auth", "login")
+	loginCmd.Stdout = os.Stdout
+	loginCmd.Stderr = os.Stderr
+	loginCmd.Stdin = os.Stdin
+	if err := loginCmd.Run(); err != nil {
+		return fmt.Errorf("failed to authenticate to Google Cloud: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Kontext

Identity Service for GKE wird zum **1. Juli 2026** abgeschaltet. Danach authentifiziert `kubectl` über `gke-gcloud-auth-plugin` gegen die aktive gcloud-Credential. Damit diese Credential eine **Workforce-Identität** (föderiert über Azure AD, Pool `ariadne-workforce`) ist, muss gcloud entsprechend eingerichtet und der Dev eingeloggt sein. Das deckte bisher kein Provisioning-Modul ab.

## Änderung

Neues Modul `gcloud-workforce-login` (`internal/provision/gcloudworkforcelogin`), registriert nach `github-auth-login`. Beim `machine provision`:

1. Erzeugt die (nicht geheime) Login-Config: `gcloud iam workforce-pools create-login-config …/providers/ariadne-workforce --output-file=~/.config/gcloud/ariadne-login-config.json` (falls nicht vorhanden).
2. `gcloud config set auth/login_config_file …` → ein `gcloud auth login` läuft danach automatisch über den Workforce-/Azure-AD-Flow.
3. Login, falls keine aktive Credential vorhanden — interaktiv im Browser (analog `github-auth-login`).

Idempotent (Skip bei vorhandener Config / bestehendem Login). `go build`/`go vet` grün, Modul erscheint in `machine provision list-modules`.

## Abhängigkeit / Hinweise

- **Runtime-Abhängigkeit auf PR #352** (`google-cloud-sdk-gke`): Das Modul ruft `gcloud`/`gke-gcloud-auth-plugin` auf — diese müssen via #352 provisioniert sein.
- **`create-login-config` ohne Auth:** Das Modul setzt voraus, dass dieser Aufruf ohne aktive Credential funktioniert (Vorab-Artefakt). Falls nicht, sollte die Login-Config statisch (Repo-Template/1Password) ausgeliefert werden.
- **`workforceProvider`** ist auf `ariadne-workforce` gesetzt — bitte gegen die tatsächliche Provider-ID im Pool prüfen (Pool- vs. Provider-Name); falls abweichend, Konstante anpassen.
- Idempotenz-Check `gcloud auth print-access-token` ist `true` für jede aktive Credential (auch normale Google-Accounts) → auf bereits Google-eingeloggten Maschinen wird der Workforce-Login übersprungen.

## kubeconfigs

Nicht Teil dieses PRs — die kommen weiter über `k8s-kubeconfig-setup` aus 1Password und müssen dort separat auf die Workforce-Variante (gke-gcloud-auth-plugin-Exec) umgestellt werden.