### PR TITLE
chore: update machine hash to 96031be

### DIFF
--- a/devbox/plugins/modac/plugin.json
+++ b/devbox/plugins/modac/plugin.json
@@ -45,7 +45,7 @@
     "go-task": {
       "version": "latest"
     },
-    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=c75b338c124f874c255b587698156ff46dbb7f3d#google-cloud-sdk-gke": {},
+    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=96031be388c83c1e7f5b5050aa329183e77d0bd3#google-cloud-sdk-gke": {},
     "htop": {
       "version": "latest"
     },
@@ -107,7 +107,7 @@
     "yq-go": {
       "version": "latest"
     },
-    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=c75b338c124f874c255b587698156ff46dbb7f3d": {}
+    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=96031be388c83c1e7f5b5050aa329183e77d0bd3": {}
   },
   "env": {
     "DEVBOX_COREPACK_ENABLED": "true",


### PR DESCRIPTION
Hebt die `&rev=`-Refs in `devbox/plugins/modac/plugin.json` (machine-Paket **und** `google-cloud-sdk-gke`) von `c75b338` auf `96031be` (aktueller main-Commit).

`c75b338` stammt aus #352 und liegt **vor** dem `gcloud-workforce-login`-Modul (#353). Dadurch wurde das `machine`-CLI aus einem Commit ohne das Modul gebaut → das Modul tauchte nicht in `machine provision` auf. `96031be` enthält #352 **und** #353.

Pendant zu #350 („Update machine hash"). Bump portabel gesetzt (das `update-machine-hash.sh` nutzt GNU-`sed -i` und bricht auf macOS — sollte separat gefixt werden).

Nach dem Merge: globale `devbox.json` auf den neuen Plugin-Commit nachziehen + `devbox install`, dann ist `gcloud-workforce-login` im CLI.