### PR TITLE
fix: make orbstack module resilient on cold start

### DIFF
--- a/nixpkgs/modac-dev-machine/internal/provision/orbstack/orbstack.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/orbstack/orbstack.go
@@ -4,9 +4,19 @@ import (
 	"bytes"
 	"fmt"
 	"os/exec"
+	"time"
 
 	"github.com/modell-aachen/machine/internal/output"
 	"github.com/modell-aachen/machine/internal/platform"
+)
+
+const (
+	statusRunning = "Running"
+	// startAttempts and pollInterval bound how long we wait for OrbStack to
+	// finish booting after a start. orbctl start can return before the engine
+	// is ready, so we poll the status instead of trusting the start exit code.
+	startAttempts = 30
+	pollInterval  = 2 * time.Second
 )
 
 // Run manages OrbStack service
@@ -23,31 +33,53 @@ func Run(out *output.Context, plat platform.Platform) error {
 }
 
 func runDarwin(out *output.Context) error {
-	// Check OrbStack status. orbctl exits non-zero when OrbStack is not
-	// running (e.g. "Stopped" returns exit status 1), so the status string
-	// is authoritative rather than the exit code.
-	statusCmd := exec.Command("orbctl", "status")
-	statusOutput, err := statusCmd.Output()
-	status := string(bytes.TrimSpace(statusOutput))
-	if status == "" {
-		return fmt.Errorf("failed to check OrbStack status: %w", err)
+	if orbStatus() == statusRunning {
+		out.Skipped("OrbStack is already running")
+		return nil
 	}
 
-	if status != "Running" {
-		// Start OrbStack
-		out.Step("Starting OrbStack")
-		if err := out.RunCommand("orbctl", "start"); err != nil {
-			return fmt.Errorf("failed to start OrbStack: %w", err)
-		}
+	// The status is "Stopped" or could not be determined (orbctl returns an
+	// empty status in some cold-start states). Both cases lead to the same
+	// action: attempt to start OrbStack. orbctl start may exit non-zero while
+	// the engine is still booting, so its error is logged but not treated as
+	// fatal; the post-start status is authoritative.
+	out.Step("Starting OrbStack")
+	if err := out.RunCommand("orbctl", "start"); err != nil {
+		out.Info(fmt.Sprintf("orbctl start exited with %v, verifying status", err))
+	}
 
-		// Login to OrbStack
-		out.Step("Logging into OrbStack")
-		if err := out.RunCommand("orbctl", "login"); err != nil {
-			return fmt.Errorf("failed to login to OrbStack: %w", err)
-		}
-	} else {
-		out.Skipped("OrbStack is already running")
+	sleep := func() { time.Sleep(pollInterval) }
+	if err := waitForRunning(orbStatus, sleep, startAttempts); err != nil {
+		return err
+	}
+
+	out.Step("Logging into OrbStack")
+	if err := out.RunCommand("orbctl", "login"); err != nil {
+		return fmt.Errorf("failed to login to OrbStack: %w", err)
 	}
 
 	return nil
+}
+
+// orbStatus returns the trimmed output of `orbctl status`. orbctl exits
+// non-zero when OrbStack is not running, so the status string is authoritative
+// rather than the exit code; an empty result means the status is unknown.
+func orbStatus() string {
+	out, _ := exec.Command("orbctl", "status").Output()
+	return string(bytes.TrimSpace(out))
+}
+
+// waitForRunning polls status until OrbStack reports running, waiting between
+// checks. It checks attempts+1 times in total and returns an error only if the
+// engine never reaches the running state.
+func waitForRunning(status func() string, wait func(), attempts int) error {
+	for i := 0; ; i++ {
+		if status() == statusRunning {
+			return nil
+		}
+		if i >= attempts {
+			return fmt.Errorf("OrbStack did not reach %q state after start", statusRunning)
+		}
+		wait()
+	}
 }

--- a/nixpkgs/modac-dev-machine/internal/provision/orbstack/orbstack_test.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/orbstack/orbstack_test.go
@@ -1,0 +1,48 @@
+package orbstack
+
+import "testing"
+
+func TestWaitForRunning(t *testing.T) {
+	tests := []struct {
+		name      string
+		statuses  []string
+		attempts  int
+		wantErr   bool
+		wantWaits int
+	}{
+		{"already running", []string{statusRunning}, 3, false, 0},
+		{"stopped then running", []string{"Stopped", statusRunning}, 3, false, 1},
+		{"empty status then running", []string{"", statusRunning}, 3, false, 1},
+		{"running on last attempt", []string{"Stopped", "Stopped", "Stopped", statusRunning}, 3, false, 3},
+		{"never running", []string{"Stopped", "Stopped", "Stopped", "Stopped"}, 3, true, 3},
+		{"never running with empty status", []string{"", "", "", ""}, 3, true, 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := 0
+			status := func() string {
+				// Repeat the final scripted value if polled beyond the script,
+				// mirroring a status that keeps reporting the same state.
+				idx := calls
+				if idx >= len(tt.statuses) {
+					idx = len(tt.statuses) - 1
+				}
+				calls++
+				return tt.statuses[idx]
+			}
+
+			waits := 0
+			wait := func() { waits++ }
+
+			err := waitForRunning(status, wait, tt.attempts)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("waitForRunning() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if waits != tt.wantWaits {
+				t.Errorf("waitForRunning() waited %d times, want %d", waits, tt.wantWaits)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The `orbstack` provisioning module aborts on fresh machines — exactly the scenario the provisioner targets. Two cold-start quirks of `orbctl` caused the failure `failed to check OrbStack status: exit status 1`:

1. **`orbctl status` can return empty stdout.** In some cold/uninitialized states `orbctl status` writes nothing to stdout while exiting non-zero. The module treated an empty status as fatal and bailed before ever attempting a start.
2. **`orbctl start` can exit non-zero while still booting.** The engine launches asynchronously, so the start command's exit code is not a reliable success signal.

Both observed on a real machine: `orbctl status` → empty/`Stopped` with exit 1, and a first `orbctl start` exiting 1 while OrbStack actually came up moments later.

## Changes

- Treat "stopped" and "status undeterminable" identically: both lead to **attempt a start** rather than aborting.
- Log a non-fatal note if `orbctl start` exits non-zero, then **poll `orbctl status`** (up to 60s) and treat the post-start status as authoritative.
- Extract `waitForRunning(status, wait, attempts)` as a pure, injectable function and cover it with table-driven tests (already-running, stopped→running, empty→running, running-on-last-attempt, never-running).

## Rationale

"Status unclear" and "stopped" should both resolve to "try to start it"; success is determined by the engine actually reaching the `Running` state, not by intermediate exit codes. Login behavior is unchanged.

## Rollback

Revert this commit; no migrations or config changes involved.