### PR TITLE
ci: auto-bump machine hash on merge to main

### DIFF
--- a/.claude/skills/update-machine-hash/scripts/update-machine-hash.sh
+++ b/.claude/skills/update-machine-hash/scripts/update-machine-hash.sh
@@ -10,12 +10,17 @@ if [ ! -f "$PLUGIN_JSON" ]; then
 fi
 
 LATEST_HASH="$(git rev-parse HEAD)"
-CURRENT_HASH="$(grep -oP '(?<=&rev=)[a-f0-9]+' "$PLUGIN_JSON")"
+# Portable across macOS (BSD) and Linux (GNU): avoid grep -oP and sed -i quirks.
+# There are multiple &rev= refs (machine + google-cloud-sdk-gke); bump them all.
+CURRENT_HASH="$(grep -oE 'rev=[a-f0-9]{40}' "$PLUGIN_JSON" | head -1 | cut -d= -f2)"
 
 if [ "$LATEST_HASH" = "$CURRENT_HASH" ]; then
   echo "Already up to date (${LATEST_HASH:0:7})"
   exit 0
 fi
 
-sed -i "s/&rev=${CURRENT_HASH}/\&rev=${LATEST_HASH}/" "$PLUGIN_JSON"
+tmp="$(mktemp)"
+sed "s/rev=${CURRENT_HASH}/rev=${LATEST_HASH}/g" "$PLUGIN_JSON" > "$tmp"
+cat "$tmp" > "$PLUGIN_JSON"
+rm -f "$tmp"
 echo "Updated machine hash: ${CURRENT_HASH:0:7} -> ${LATEST_HASH:0:7}"

--- a/.github/workflows/update-machine-hash.yml
+++ b/.github/workflows/update-machine-hash.yml
@@ -1,0 +1,38 @@
+---
+name: Update machine hash
+
+"on":
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  update-machine-hash:
+    # Skip the bot's own bump commit (and pushes via GITHUB_TOKEN do not
+    # re-trigger workflows anyway).
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Bump machine hash
+        run: |
+          bash .claude/skills/update-machine-hash/scripts/update-machine-hash.sh
+
+      - name: Commit and push if changed
+        run: |
+          set -euo pipefail
+          if git diff --quiet; then
+            echo "Machine hash already up to date"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email \
+            "41898282+github-actions[bot]@users.noreply.github.com"
+          git add devbox/plugins/modac/plugin.json
+          short="$(git rev-parse --short HEAD)"
+          git commit -m "chore: update machine hash to ${short} [skip ci]"
+          git push


### PR DESCRIPTION
## Problem

`plugin.json` pinnt das `machine`-CLI **und** `google-cloud-sdk-gke` per fixem `&rev=` auf einen Commit. Jede Änderung braucht einen manuellen „Update machine hash"-Bump (#350-Stil). Das ist fehleranfällig: #352 pinnte auf `c75b338`, der das später in #353 ergänzte Modul nicht enthielt → `gcloud-workforce-login` tauchte nicht in `machine provision` auf (gefixt durch #354). Zusätzlich brach das `update-machine-hash.sh` auf macOS (GNU-`sed`/`grep -oP`).

## Änderung

- **Neuer Workflow** `.github/workflows/update-machine-hash.yml`: bumpt bei Push auf `main` die `&rev=`-Refs in `plugin.json` automatisch auf den Merge-Commit und pusht den Bump zurück. `main` ist ungeschützt → Direct-Push; Pushes via `GITHUB_TOKEN` triggern keine erneuten Workflow-Läufe, `[skip ci]` zusätzlich als Backstop. Kein manueller Hash-Bump mehr nötig.
- **`update-machine-hash.sh` portabel** (bleibt als manueller Fallback): kein `grep -oP`/GNU-`sed -i` mehr, sondern reines POSIX-`sed` über Temp-Datei (kein perl/keine Zusatz-Abhängigkeit), und ersetzt **alle** `&rev=`-Vorkommen statt nur des ersten.

## Hinweise

- Es gibt **keine** zweite Pin-Ebene: die globale `devbox.json` bindet das Plugin per lokalem `path:`-Include ein → Updates kommen per `git pull` des lokalen Checkouts; der einzige Pin ist `&rev=` in `plugin.json`, den dieser Workflow pflegt.
- yamllint (`.yamllint.yml`) clean, `bash -n` ok, sed-Substitution getestet.