### PR TITLE
ci: fix update-machine-hash trigger (canonical on + workflow_dispatch)

### DIFF
--- a/.github/workflows/update-machine-hash.yml
+++ b/.github/workflows/update-machine-hash.yml
@@ -1,9 +1,10 @@
 ---
 name: Update machine hash
 
-"on":
+on:  # yamllint disable-line rule:truthy
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Follow-up zu #356. Der Auto-Bump-Workflow hatte **null Runs**:

1. Er wurde im selben Merge eingeführt, der ihn enthält — GitHub triggert einen Workflow **nicht** auf dem Push, der ihn erstmals einbringt (erst beim nächsten Push auf `main`).
2. Zusätzliches Risiko: der gequotete `"on":`-Key.

Fix: kanonisches `on:` (mit `# yamllint disable-line rule:truthy`) + `workflow_dispatch:` zum manuellen Auslösen. Beim Merge dieses PRs (= nächster Push auf main) sollte der Workflow erstmals laufen und den Hash bumpen; alternativ manuell über „Run workflow".

yamllint clean.