### PR TITLE
feat: dynamic GKE workforce group refresh

### DIFF
--- a/devbox/plugins/modac/plugin.json
+++ b/devbox/plugins/modac/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "MODAC",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "packages": {
     "age": {
       "version": "latest"
@@ -119,6 +119,7 @@
     "QWIKI_EVENTS_HOST": "https://events.qluster.localhost",
     "QWIKI_DEVELOPMENT_ROOT_CA": "$HOME/.local/share/mkcert",
     "ASDF_DATA_DIR": "$HOME/.asdf",
+    "GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES": "1",
     "KREW_ROOT": "$HOME/.krew",
     "XDG_DATA_DIRS": "$HOME/.local/share/devbox/global/default/.devbox/nix/profile/default/share:$XDG_DATA_DIRS",
     "PATH": "$HOME/.krew/bin:$HOME/.local/bin:$HOME/.asdf/shims:$HOME/.pyenv/bin:$PATH"

--- a/devbox/plugins/modac/plugin.json
+++ b/devbox/plugins/modac/plugin.json
@@ -119,7 +119,6 @@
     "QWIKI_EVENTS_HOST": "https://events.qluster.localhost",
     "QWIKI_DEVELOPMENT_ROOT_CA": "$HOME/.local/share/mkcert",
     "ASDF_DATA_DIR": "$HOME/.asdf",
-    "GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES": "1",
     "KREW_ROOT": "$HOME/.krew",
     "XDG_DATA_DIRS": "$HOME/.local/share/devbox/global/default/.devbox/nix/profile/default/share:$XDG_DATA_DIRS",
     "PATH": "$HOME/.krew/bin:$HOME/.local/bin:$HOME/.asdf/shims:$HOME/.pyenv/bin:$PATH"

--- a/nixpkgs/modac-dev-machine/internal/provision/gcloudworkforcelogin/ariadne-gcp-workforce-login
+++ b/nixpkgs/modac-dev-machine/internal/provision/gcloudworkforcelogin/ariadne-gcp-workforce-login
@@ -4,7 +4,15 @@
 # Default mode mints a fresh Azure AD OIDC id_token from a stored refresh token
 # and prints it per Google's executable-sourced credential spec. gcloud runs
 # this on every STS token refresh, so GKE re-evaluates the `groups` claim
-# without an interactive re-login (refresh token is good ~90 days).
+# without an interactive re-login.
+#
+# The refresh token is a long-lived (~90 day) secret that carries the groups
+# claim (and thus GKE access). It is stored as a 0600 file under the gcloud
+# config dir — same handling as gcloud/kubeconfig credentials — and is
+# intentionally NOT kept in 1Password, deviating from the team secrets
+# convention. Azure does not single-use refresh tokens for this public/native
+# client (24h single-use applies only to SPA redirect URIs), so concurrent
+# refreshes are safe; see the lock in refresh_and_emit.
 #
 #   ariadne-gcp-workforce-login                  # refresh + emit (gcloud calls this)
 #   ariadne-gcp-workforce-login --login          # one-time interactive device-code login
@@ -39,7 +47,7 @@ write_rt() {
 }
 
 device_login() {
-  local resp device_code interval idt err
+  local resp device_code interval idt new_rt err
   resp=$(curl -sS -X POST "${AUTHORITY}/devicecode" \
     --data-urlencode "client_id=${CLIENT_ID}" \
     --data-urlencode "scope=${SCOPE}")
@@ -47,9 +55,10 @@ device_login() {
     echo "devicecode error: $(jq -r '.error_description // .error' <<<"$resp")" >&2
     exit 1
   fi
-  device_code=$(jq -r '.device_code' <<<"$resp")
+  device_code=$(jq -r '.device_code // empty' <<<"$resp")
+  [ -n "$device_code" ] || { echo "devicecode response missing device_code (malformed response?)" >&2; exit 1; }
   interval=$(jq -r '.interval // 5' <<<"$resp")
-  printf '\n  %s\n\n' "$(jq -r '.message' <<<"$resp")" >&2
+  printf '\n  %s\n\n' "$(jq -r '.message // "open https://login.microsoft.com/device"' <<<"$resp")" >&2
   while true; do
     sleep "$interval"
     resp=$(curl -sS -X POST "${AUTHORITY}/token" \
@@ -58,7 +67,9 @@ device_login() {
       --data-urlencode "device_code=${device_code}") || true
     idt=$(jq -r '.id_token // empty' <<<"$resp")
     if [ -n "$idt" ]; then
-      write_rt "$(jq -r '.refresh_token' <<<"$resp")"
+      new_rt=$(jq -r '.refresh_token // empty' <<<"$resp")
+      [ -n "$new_rt" ] || { echo "device login succeeded but response carried no refresh_token" >&2; exit 1; }
+      write_rt "$new_rt"
       echo "seeded refresh token -> ${RT_FILE}" >&2
       return 0
     fi
@@ -77,6 +88,15 @@ device_login() {
 refresh_and_emit() {
   [ -f "$RT_FILE" ] || emit_failure "NO_REFRESH_TOKEN" \
     "refresh token missing; run: ariadne-gcp-workforce-login --login"
+  # Serialize read-rotate-write so concurrent kubectl calls can't clobber a
+  # freshly rotated refresh token. flock auto-releases on process exit (incl.
+  # kill), so it cannot deadlock; where flock is unavailable (stock macOS) we
+  # proceed without it — benign because this public/native client's refresh
+  # tokens are not single-use (see header).
+  if command -v flock >/dev/null 2>&1; then
+    exec 9>"${RT_FILE}.lock"
+    flock 9
+  fi
   local rt resp idt new_rt
   rt=$(cat "$RT_FILE")
   [ -n "$rt" ] || emit_failure "EMPTY_REFRESH_TOKEN" "refresh token file is empty; run --login"
@@ -95,9 +115,10 @@ refresh_and_emit() {
   emit_success "$idt"
 }
 
-# clear_caches drops gcloud's short-lived access-token cache and the
-# gke-gcloud-auth-plugin cache. The long-lived refresh token is untouched, so
-# the next call re-mints a fresh id_token (with current groups) via the helper.
+# clear_caches drops the short-lived access-token caches so the next call
+# re-mints a fresh id_token (with current groups). The long-lived refresh token
+# is untouched. NOTE: access_tokens.db is gcloud-wide — other gcloud accounts
+# lose their cached access tokens too, but simply re-mint on next use (harmless).
 clear_caches() {
   rm -f "${GCLOUD_DIR}/access_tokens.db" "${PLUGIN_CACHE}"
 }

--- a/nixpkgs/modac-dev-machine/internal/provision/gcloudworkforcelogin/ariadne-gcp-workforce-login
+++ b/nixpkgs/modac-dev-machine/internal/provision/gcloudworkforcelogin/ariadne-gcp-workforce-login
@@ -131,6 +131,16 @@ get_token() {
   emit_exec_credential "$at" "$exp"
 }
 
+# check_session validates the full path (Azure refresh + STS exchange), so
+# provisioning catches a broken exchange (audience, QUOTA_PROJECT,
+# serviceusage permission) instead of reporting a healthy session that only
+# fails on the first kubectl.
+check_session() {
+  local idt
+  idt=$(mint_azure_idtoken)
+  sts_exchange "$idt" >/dev/null
+}
+
 device_login() {
   local resp device_code interval idt new_rt err
   resp=$(curl -sS -X POST "${AUTHORITY}/devicecode" \
@@ -193,7 +203,8 @@ EOF
 case "${1:-get-token}" in
   get-token) get_token ;;
   --login) device_login ;;
-  --check) mint_azure_idtoken >/dev/null ;; # internal: validate the session (used by provisioning)
+  --has-session) test -s "$RT_FILE" ;; # internal: is a refresh token present?
+  --check) check_session ;;            # internal: full validation (Azure + STS)
   --force-refresh) force_refresh ;;
   --logout) logout ;;
   --help | -h) usage ;;

--- a/nixpkgs/modac-dev-machine/internal/provision/gcloudworkforcelogin/ariadne-gcp-workforce-login
+++ b/nixpkgs/modac-dev-machine/internal/provision/gcloudworkforcelogin/ariadne-gcp-workforce-login
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# ariadne-gcp-workforce-login — Workforce Identity executable-sourced credential.
+#
+# Default mode mints a fresh Azure AD OIDC id_token from a stored refresh token
+# and prints it per Google's executable-sourced credential spec. gcloud runs
+# this on every STS token refresh, so GKE re-evaluates the `groups` claim
+# without an interactive re-login (refresh token is good ~90 days).
+#
+#   ariadne-gcp-workforce-login                  # refresh + emit (gcloud calls this)
+#   ariadne-gcp-workforce-login --login          # one-time interactive device-code login
+#   ariadne-gcp-workforce-login --force-refresh  # drop cached tokens so the next kubectl re-pulls groups
+#   ariadne-gcp-workforce-login --logout         # end the session (remove refresh token + caches)
+#
+# Requires curl and jq (both provided by the devbox environment).
+set -euo pipefail
+
+TENANT="7838a88f-3a81-4c75-a67b-bf0715776375"
+CLIENT_ID="090c1876-72d3-4d5f-8d42-85c7d7e635a4" # public client, no secret
+SCOPE="openid offline_access profile email"
+AUTHORITY="https://login.microsoftonline.com/${TENANT}/oauth2/v2.0"
+GCLOUD_DIR="${CLOUDSDK_CONFIG:-${HOME}/.config/gcloud}"
+RT_FILE="${GCLOUD_DIR}/ariadne-azure-refresh-token"
+PLUGIN_CACHE="${HOME}/.kube/gke_gcloud_auth_plugin_cache"
+
+emit_success() {
+  jq -nc --arg t "$1" \
+    '{version:1,success:true,token_type:"urn:ietf:params:oauth:token-type:id_token",id_token:$t}'
+}
+
+emit_failure() {
+  jq -nc --arg c "$1" --arg m "$2" '{version:1,success:false,code:$c,message:$m}'
+  exit 1
+}
+
+write_rt() {
+  local tmp="${RT_FILE}.tmp"
+  (umask 077; printf '%s' "$1" >"$tmp")
+  mv -f "$tmp" "$RT_FILE"
+}
+
+device_login() {
+  local resp device_code interval idt err
+  resp=$(curl -sS -X POST "${AUTHORITY}/devicecode" \
+    --data-urlencode "client_id=${CLIENT_ID}" \
+    --data-urlencode "scope=${SCOPE}")
+  if [ -n "$(jq -r '.error // empty' <<<"$resp")" ]; then
+    echo "devicecode error: $(jq -r '.error_description // .error' <<<"$resp")" >&2
+    exit 1
+  fi
+  device_code=$(jq -r '.device_code' <<<"$resp")
+  interval=$(jq -r '.interval // 5' <<<"$resp")
+  printf '\n  %s\n\n' "$(jq -r '.message' <<<"$resp")" >&2
+  while true; do
+    sleep "$interval"
+    resp=$(curl -sS -X POST "${AUTHORITY}/token" \
+      --data-urlencode "client_id=${CLIENT_ID}" \
+      --data-urlencode "grant_type=urn:ietf:params:oauth:grant-type:device_code" \
+      --data-urlencode "device_code=${device_code}") || true
+    idt=$(jq -r '.id_token // empty' <<<"$resp")
+    if [ -n "$idt" ]; then
+      write_rt "$(jq -r '.refresh_token' <<<"$resp")"
+      echo "seeded refresh token -> ${RT_FILE}" >&2
+      return 0
+    fi
+    err=$(jq -r '.error // "unknown"' <<<"$resp")
+    case "$err" in
+      authorization_pending) ;;
+      slow_down) interval=$((interval + 5)) ;;
+      *)
+        echo "device login failed: $(jq -r '.error_description // .error' <<<"$resp")" >&2
+        exit 1
+        ;;
+    esac
+  done
+}
+
+refresh_and_emit() {
+  [ -f "$RT_FILE" ] || emit_failure "NO_REFRESH_TOKEN" \
+    "refresh token missing; run: ariadne-gcp-workforce-login --login"
+  local rt resp idt new_rt
+  rt=$(cat "$RT_FILE")
+  [ -n "$rt" ] || emit_failure "EMPTY_REFRESH_TOKEN" "refresh token file is empty; run --login"
+  resp=$(curl -sS -X POST "${AUTHORITY}/token" \
+    --data-urlencode "client_id=${CLIENT_ID}" \
+    --data-urlencode "grant_type=refresh_token" \
+    --data-urlencode "refresh_token=${rt}" \
+    --data-urlencode "scope=${SCOPE}") || emit_failure "NETWORK_ERROR" "Azure token request failed"
+  idt=$(jq -r '.id_token // empty' <<<"$resp")
+  [ -n "$idt" ] || emit_failure "AZURE_TOKEN_ERROR" \
+    "no id_token: $(jq -rc '.error_description // .error // "unknown"' <<<"$resp")"
+  new_rt=$(jq -r '.refresh_token // empty' <<<"$resp")
+  if [ -n "$new_rt" ] && [ "$new_rt" != "$rt" ]; then
+    write_rt "$new_rt"
+  fi
+  emit_success "$idt"
+}
+
+# clear_caches drops gcloud's short-lived access-token cache and the
+# gke-gcloud-auth-plugin cache. The long-lived refresh token is untouched, so
+# the next call re-mints a fresh id_token (with current groups) via the helper.
+clear_caches() {
+  rm -f "${GCLOUD_DIR}/access_tokens.db" "${PLUGIN_CACHE}"
+}
+
+force_refresh() {
+  clear_caches
+  echo "Cleared cached tokens. Your next kubectl call mints a fresh token with current group memberships." >&2
+}
+
+logout() {
+  clear_caches
+  rm -f "$RT_FILE"
+  echo "Signed out: removed the Azure refresh token and cached tokens." >&2
+  echo "Run 'ariadne-gcp-workforce-login --login' to sign in again." >&2
+}
+
+usage() {
+  cat >&2 <<'EOF'
+ariadne-gcp-workforce-login — GKE Workforce Identity credential helper
+
+  (no args)         mint a fresh id_token for gcloud (invoked automatically)
+  --login           interactive device-code login (one-time, ~90 day session)
+  --force-refresh   drop cached tokens so the next kubectl re-pulls your groups
+  --logout          end the session (remove refresh token + cached tokens)
+  --help            show this help
+EOF
+}
+
+case "${1:-}" in
+  --login) device_login ;;
+  --force-refresh) force_refresh ;;
+  --logout) logout ;;
+  --help | -h) usage ;;
+  "") refresh_and_emit ;;
+  *)
+    echo "unknown argument: $1" >&2
+    usage
+    exit 2
+    ;;
+esac

--- a/nixpkgs/modac-dev-machine/internal/provision/gcloudworkforcelogin/ariadne-gcp-workforce-login
+++ b/nixpkgs/modac-dev-machine/internal/provision/gcloudworkforcelogin/ariadne-gcp-workforce-login
@@ -1,49 +1,134 @@
 #!/usr/bin/env bash
-# ariadne-gcp-workforce-login — Workforce Identity executable-sourced credential.
+# ariadne-gcp-workforce-login — GKE Workforce Identity kubectl credential plugin.
 #
-# Default mode mints a fresh Azure AD OIDC id_token from a stored refresh token
-# and prints it per Google's executable-sourced credential spec. gcloud runs
-# this on every STS token refresh, so GKE re-evaluates the `groups` claim
-# without an interactive re-login.
+# Acts as a client-go exec credential plugin: mints a fresh Azure AD id_token
+# from a stored refresh token, exchanges it at Google STS for a federated access
+# token, and prints an ExecCredential for kubectl/k9s/Lens. gcloud is NOT on the
+# runtime path, so no GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES gate is required.
+# GKE re-evaluates the `groups` claim whenever the cached token is re-minted.
 #
-# The refresh token is a long-lived (~90 day) secret that carries the groups
-# claim (and thus GKE access). It is stored as a 0600 file under the gcloud
-# config dir — same handling as gcloud/kubeconfig credentials — and is
-# intentionally NOT kept in 1Password, deviating from the team secrets
-# convention. Azure does not single-use refresh tokens for this public/native
-# client (24h single-use applies only to SPA redirect URIs), so concurrent
-# refreshes are safe; see the lock in refresh_and_emit.
-#
-#   ariadne-gcp-workforce-login                  # refresh + emit (gcloud calls this)
+#   ariadne-gcp-workforce-login get-token        # ExecCredential (the kubeconfig calls this)
 #   ariadne-gcp-workforce-login --login          # one-time interactive device-code login
-#   ariadne-gcp-workforce-login --force-refresh  # drop cached tokens so the next kubectl re-pulls groups
-#   ariadne-gcp-workforce-login --logout         # end the session (remove refresh token + caches)
+#   ariadne-gcp-workforce-login --force-refresh  # drop the cached access token -> re-pull groups
+#   ariadne-gcp-workforce-login --logout         # remove refresh token + cached access token
 #
-# Requires curl and jq (both provided by the devbox environment).
+# The refresh token is a long-lived (~90 day) 0600 secret carrying the groups
+# claim (and thus GKE access). It is kept on disk (same handling as
+# gcloud/kubeconfig credentials), intentionally not in 1Password. Azure does not
+# single-use refresh tokens for this public/native client (24h single-use is
+# SPA-only), so concurrent refreshes are safe.
+#
+# Requires curl and jq. The helper prepends the devbox profile bin to PATH so it
+# resolves them even when launched by k9s/Lens/Finder with a minimal PATH.
 set -euo pipefail
+
+# Make the helper self-sufficient regardless of the caller's PATH.
+_devbox_bin="${HOME}/.local/share/devbox/global/default/.devbox/nix/profile/default/bin"
+PATH="${_devbox_bin}:${HOME}/.local/bin:${PATH}:/usr/bin:/bin"
 
 TENANT="7838a88f-3a81-4c75-a67b-bf0715776375"
 CLIENT_ID="090c1876-72d3-4d5f-8d42-85c7d7e635a4" # public client, no secret
 SCOPE="openid offline_access profile email"
 AUTHORITY="https://login.microsoftonline.com/${TENANT}/oauth2/v2.0"
+AUDIENCE="//iam.googleapis.com/locations/global/workforcePools/ariadne-workforce/providers/ariadne-workforce"
+QUOTA_PROJECT="modac-dev" # billing/quota project for the STS exchange; principal needs serviceusage.services.use
+STS_URL="https://sts.googleapis.com/v1/token"
 GCLOUD_DIR="${CLOUDSDK_CONFIG:-${HOME}/.config/gcloud}"
 RT_FILE="${GCLOUD_DIR}/ariadne-azure-refresh-token"
-PLUGIN_CACHE="${HOME}/.kube/gke_gcloud_auth_plugin_cache"
+TOKEN_CACHE="${GCLOUD_DIR}/ariadne-access-token.json"
 
-emit_success() {
-  jq -nc --arg t "$1" \
-    '{version:1,success:true,token_type:"urn:ietf:params:oauth:token-type:id_token",id_token:$t}'
-}
-
-emit_failure() {
-  jq -nc --arg c "$1" --arg m "$2" '{version:1,success:false,code:$c,message:$m}'
+die() {
+  echo "ariadne-gcp-workforce-login: $*" >&2
   exit 1
 }
 
-write_rt() {
-  local tmp="${RT_FILE}.tmp"
-  (umask 077; printf '%s' "$1" >"$tmp")
-  mv -f "$tmp" "$RT_FILE"
+write_secret() { # write_secret <file> <content>
+  local tmp="$1.tmp"
+  (umask 077; printf '%s' "$2" >"$tmp")
+  mv -f "$1.tmp" "$1"
+}
+
+epoch_to_rfc3339() { # portable across GNU and BSD date
+  date -u -r "$1" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "@$1" +%Y-%m-%dT%H:%M:%SZ
+}
+
+# mint_azure_idtoken prints a fresh Azure AD id_token, rotating the stored
+# refresh token. Serialized with flock so concurrent callers can't clobber a
+# freshly rotated token; flock auto-releases on exit (incl. kill) so it cannot
+# deadlock, and is simply skipped where unavailable (stock macOS).
+mint_azure_idtoken() {
+  [ -f "$RT_FILE" ] || die "not signed in; run: ariadne-gcp-workforce-login --login"
+  if command -v flock >/dev/null 2>&1; then
+    exec 9>"${RT_FILE}.lock"
+    flock 9
+  fi
+  local rt resp idt new_rt
+  rt=$(cat "$RT_FILE")
+  [ -n "$rt" ] || die "refresh token file is empty; run --login"
+  resp=$(curl -sS -X POST "${AUTHORITY}/token" \
+    --data-urlencode "client_id=${CLIENT_ID}" \
+    --data-urlencode "grant_type=refresh_token" \
+    --data-urlencode "refresh_token=${rt}" \
+    --data-urlencode "scope=${SCOPE}") || die "Azure token request failed"
+  idt=$(jq -r '.id_token // empty' <<<"$resp")
+  [ -n "$idt" ] || die "Azure refresh failed: $(jq -rc '.error_description // .error // "unknown"' <<<"$resp")"
+  new_rt=$(jq -r '.refresh_token // empty' <<<"$resp")
+  if [ -n "$new_rt" ] && [ "$new_rt" != "$rt" ]; then
+    write_secret "$RT_FILE" "$new_rt"
+  fi
+  printf '%s' "$idt"
+}
+
+# sts_exchange trades an Azure id_token for a Google access token; prints
+# "<access_token> <expires_in>".
+sts_exchange() { # sts_exchange <id_token>
+  local resp at ei
+  resp=$(curl -sS -X POST "$STS_URL" \
+    --data-urlencode "audience=${AUDIENCE}" \
+    --data-urlencode "grant_type=urn:ietf:params:oauth:grant-type:token-exchange" \
+    --data-urlencode "requested_token_type=urn:ietf:params:oauth:token-type:access_token" \
+    --data-urlencode "scope=https://www.googleapis.com/auth/cloud-platform" \
+    --data-urlencode "subject_token_type=urn:ietf:params:oauth:token-type:id_token" \
+    --data-urlencode "options={\"userProject\":\"${QUOTA_PROJECT}\"}" \
+    --data-urlencode "subject_token=$1") || die "STS token exchange request failed"
+  at=$(jq -r '.access_token // empty' <<<"$resp")
+  [ -n "$at" ] || die "STS exchange failed: $(jq -rc '.error_description // .error // "unknown"' <<<"$resp")"
+  ei=$(jq -r '.expires_in // 3600' <<<"$resp")
+  printf '%s %s' "$at" "$ei"
+}
+
+emit_exec_credential() { # emit_exec_credential <access_token> <expires_at_epoch>
+  local api_version="client.authentication.k8s.io/v1"
+  if [ -n "${KUBERNETES_EXEC_INFO:-}" ]; then
+    api_version=$(printf '%s' "$KUBERNETES_EXEC_INFO" | jq -r '.apiVersion // "client.authentication.k8s.io/v1"')
+  fi
+  jq -nc --arg v "$api_version" --arg t "$1" --arg e "$(epoch_to_rfc3339 "$2")" \
+    '{apiVersion:$v,kind:"ExecCredential",status:{token:$t,expirationTimestamp:$e}}'
+}
+
+# get_token serves a cached access token until ~1min before expiry, otherwise
+# mints a fresh one (which re-evaluates group memberships) and caches it.
+get_token() {
+  local now exp at
+  now=$(date +%s)
+  if [ -f "$TOKEN_CACHE" ]; then
+    exp=$(jq -r '.expires_at // 0' <"$TOKEN_CACHE" 2>/dev/null || echo 0)
+    if [ "$exp" -gt $((now + 60)) ]; then
+      at=$(jq -r '.access_token // empty' <"$TOKEN_CACHE")
+      if [ -n "$at" ]; then
+        emit_exec_credential "$at" "$exp"
+        return 0
+      fi
+    fi
+  fi
+  local idt pair ei
+  idt=$(mint_azure_idtoken)
+  pair=$(sts_exchange "$idt")
+  at=${pair% *}
+  ei=${pair##* }
+  exp=$((now + ei))
+  write_secret "$TOKEN_CACHE" "$(jq -nc --arg t "$at" --argjson e "$exp" '{access_token:$t,expires_at:$e}')"
+  emit_exec_credential "$at" "$exp"
 }
 
 device_login() {
@@ -52,11 +137,10 @@ device_login() {
     --data-urlencode "client_id=${CLIENT_ID}" \
     --data-urlencode "scope=${SCOPE}")
   if [ -n "$(jq -r '.error // empty' <<<"$resp")" ]; then
-    echo "devicecode error: $(jq -r '.error_description // .error' <<<"$resp")" >&2
-    exit 1
+    die "devicecode error: $(jq -r '.error_description // .error' <<<"$resp")"
   fi
   device_code=$(jq -r '.device_code // empty' <<<"$resp")
-  [ -n "$device_code" ] || { echo "devicecode response missing device_code (malformed response?)" >&2; exit 1; }
+  [ -n "$device_code" ] || die "devicecode response missing device_code (malformed response?)"
   interval=$(jq -r '.interval // 5' <<<"$resp")
   printf '\n  %s\n\n' "$(jq -r '.message // "open https://login.microsoft.com/device"' <<<"$resp")" >&2
   while true; do
@@ -68,8 +152,9 @@ device_login() {
     idt=$(jq -r '.id_token // empty' <<<"$resp")
     if [ -n "$idt" ]; then
       new_rt=$(jq -r '.refresh_token // empty' <<<"$resp")
-      [ -n "$new_rt" ] || { echo "device login succeeded but response carried no refresh_token" >&2; exit 1; }
-      write_rt "$new_rt"
+      [ -n "$new_rt" ] || die "device login succeeded but response carried no refresh_token"
+      write_secret "$RT_FILE" "$new_rt"
+      rm -f "$TOKEN_CACHE"
       echo "seeded refresh token -> ${RT_FILE}" >&2
       return 0
     fi
@@ -77,82 +162,41 @@ device_login() {
     case "$err" in
       authorization_pending) ;;
       slow_down) interval=$((interval + 5)) ;;
-      *)
-        echo "device login failed: $(jq -r '.error_description // .error' <<<"$resp")" >&2
-        exit 1
-        ;;
+      *) die "device login failed: $(jq -r '.error_description // .error' <<<"$resp")" ;;
     esac
   done
 }
 
-refresh_and_emit() {
-  [ -f "$RT_FILE" ] || emit_failure "NO_REFRESH_TOKEN" \
-    "refresh token missing; run: ariadne-gcp-workforce-login --login"
-  # Serialize read-rotate-write so concurrent kubectl calls can't clobber a
-  # freshly rotated refresh token. flock auto-releases on process exit (incl.
-  # kill), so it cannot deadlock; where flock is unavailable (stock macOS) we
-  # proceed without it — benign because this public/native client's refresh
-  # tokens are not single-use (see header).
-  if command -v flock >/dev/null 2>&1; then
-    exec 9>"${RT_FILE}.lock"
-    flock 9
-  fi
-  local rt resp idt new_rt
-  rt=$(cat "$RT_FILE")
-  [ -n "$rt" ] || emit_failure "EMPTY_REFRESH_TOKEN" "refresh token file is empty; run --login"
-  resp=$(curl -sS -X POST "${AUTHORITY}/token" \
-    --data-urlencode "client_id=${CLIENT_ID}" \
-    --data-urlencode "grant_type=refresh_token" \
-    --data-urlencode "refresh_token=${rt}" \
-    --data-urlencode "scope=${SCOPE}") || emit_failure "NETWORK_ERROR" "Azure token request failed"
-  idt=$(jq -r '.id_token // empty' <<<"$resp")
-  [ -n "$idt" ] || emit_failure "AZURE_TOKEN_ERROR" \
-    "no id_token: $(jq -rc '.error_description // .error // "unknown"' <<<"$resp")"
-  new_rt=$(jq -r '.refresh_token // empty' <<<"$resp")
-  if [ -n "$new_rt" ] && [ "$new_rt" != "$rt" ]; then
-    write_rt "$new_rt"
-  fi
-  emit_success "$idt"
-}
-
-# clear_caches drops the short-lived access-token caches so the next call
-# re-mints a fresh id_token (with current groups). The long-lived refresh token
-# is untouched. NOTE: access_tokens.db is gcloud-wide — other gcloud accounts
-# lose their cached access tokens too, but simply re-mint on next use (harmless).
-clear_caches() {
-  rm -f "${GCLOUD_DIR}/access_tokens.db" "${PLUGIN_CACHE}"
-}
-
 force_refresh() {
-  clear_caches
-  echo "Cleared cached tokens. Your next kubectl call mints a fresh token with current group memberships." >&2
+  rm -f "$TOKEN_CACHE"
+  echo "Cleared the cached access token. Your next kubectl call re-mints one with current group memberships." >&2
 }
 
 logout() {
-  clear_caches
-  rm -f "$RT_FILE"
-  echo "Signed out: removed the Azure refresh token and cached tokens." >&2
+  rm -f "$TOKEN_CACHE" "$RT_FILE"
+  echo "Signed out: removed the refresh token and cached access token." >&2
   echo "Run 'ariadne-gcp-workforce-login --login' to sign in again." >&2
 }
 
 usage() {
   cat >&2 <<'EOF'
-ariadne-gcp-workforce-login — GKE Workforce Identity credential helper
+ariadne-gcp-workforce-login — GKE Workforce Identity kubectl credential plugin
 
-  (no args)         mint a fresh id_token for gcloud (invoked automatically)
+  get-token         print an ExecCredential for kubectl (invoked by the kubeconfig)
   --login           interactive device-code login (one-time, ~90 day session)
-  --force-refresh   drop cached tokens so the next kubectl re-pulls your groups
-  --logout          end the session (remove refresh token + cached tokens)
+  --force-refresh   drop the cached access token so the next kubectl re-pulls your groups
+  --logout          end the session (remove refresh token + cached access token)
   --help            show this help
 EOF
 }
 
-case "${1:-}" in
+case "${1:-get-token}" in
+  get-token) get_token ;;
   --login) device_login ;;
+  --check) mint_azure_idtoken >/dev/null ;; # internal: validate the session (used by provisioning)
   --force-refresh) force_refresh ;;
   --logout) logout ;;
   --help | -h) usage ;;
-  "") refresh_and_emit ;;
   *)
     echo "unknown argument: $1" >&2
     usage

--- a/nixpkgs/modac-dev-machine/internal/provision/gcloudworkforcelogin/gcloudworkforcelogin.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/gcloudworkforcelogin/gcloudworkforcelogin.go
@@ -1,9 +1,7 @@
 package gcloudworkforcelogin
 
 import (
-	"bytes"
 	_ "embed"
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -14,33 +12,25 @@ import (
 )
 
 // ariadne-gcp-workforce-login is shipped with the binary and installed into the
-// user's PATH. It mints fresh Azure AD id_tokens from a stored refresh token so
-// GKE sees current group memberships on every token refresh.
+// user's PATH. It is a client-go exec credential plugin: it mints a fresh Azure
+// AD id_token from a stored refresh token, exchanges it at Google STS, and
+// prints an ExecCredential for kubectl. Because it talks to STS directly, gcloud
+// is not on the runtime path and no GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES
+// gate is needed anywhere. GKE re-evaluates the user's group memberships
+// whenever the cached token is re-minted.
+//
+// The kubeconfig that wires GKE users to this helper is managed by the team in
+// 1Password, so this module only installs the helper and performs the one-time
+// interactive device-code login. Workforce Identity Federation replaces Identity
+// Service for GKE (discontinued 2026-07-01).
 //
 //go:embed ariadne-gcp-workforce-login
 var execScript []byte
 
-// Workforce Identity Federation, federated via Azure AD, backs GKE cluster
-// authentication (Identity Service for GKE is discontinued on 2026-07-01).
-// Instead of a browser sign-in that freezes the group set until the next login,
-// we configure an executable-sourced external_account credential: gke-gcloud-
-// auth-plugin obtains a token from gcloud, gcloud re-runs the executable on
-// every STS refresh, and the executable re-mints an Azure id_token whose
-// `groups` claim reflects current (incl. JIT-activated) memberships.
-const (
-	workforcePool     = "ariadne-workforce"
-	workforceProvider = "ariadne-workforce"
-	// quotaProject attributes API quota/billing for the org-wide workforce
-	// identity's calls; the principal needs serviceusage.services.use on it.
-	quotaProject = "modac-dev"
-	execName     = "ariadne-gcp-workforce-login"
-	// allowExecutables is gcloud's security gate for executable-sourced creds.
-	allowExecutables = "GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES=1"
-)
+const execName = "ariadne-gcp-workforce-login"
 
-// Run installs the credential helper, writes the credential config, ensures a
-// valid Azure refresh token (one-time interactive device-code login), and
-// activates the credential so gke-gcloud-auth-plugin can obtain GKE tokens.
+// Run installs the credential helper and ensures a valid Azure refresh token,
+// signing the user in interactively (device code) if necessary.
 func Run(out *output.Context, plat platform.Platform) error {
 	_ = plat
 
@@ -49,30 +39,19 @@ func Run(out *output.Context, plat platform.Platform) error {
 		return fmt.Errorf("failed to determine home directory: %w", err)
 	}
 	execPath := filepath.Join(home, ".local", "bin", execName)
-	credConfig := filepath.Join(home, ".config", "gcloud", "ariadne-cred-config.json")
 
 	if err := installExecutable(out, execPath); err != nil {
 		return err
 	}
-	if err := writeCredConfig(out, credConfig, execPath); err != nil {
-		return err
+
+	if sessionValid(execPath) {
+		out.Skipped("Workforce session already valid")
+		return nil
 	}
 
-	if refreshTokenValid(execPath) {
-		out.Skipped("Azure refresh token already valid")
-	} else {
-		out.Step("Logging into Azure AD via device code (interactive, one-time)")
-		if err := deviceLogin(execPath); err != nil {
-			return fmt.Errorf("failed to obtain Azure refresh token: %w", err)
-		}
-	}
-
-	out.Step("Activating the Workforce Identity credential for gcloud")
-	if err := activateCredential(out, credConfig); err != nil {
-		return fmt.Errorf("failed to activate workforce credential: %w", err)
-	}
-	if err := verifyCredential(); err != nil {
-		return fmt.Errorf("workforce credential is not usable: %w", err)
+	out.Step("Logging into Azure AD via device code (interactive, one-time)")
+	if err := deviceLogin(execPath); err != nil {
+		return fmt.Errorf("failed to obtain Azure refresh token: %w", err)
 	}
 
 	return nil
@@ -89,54 +68,10 @@ func installExecutable(out *output.Context, execPath string) error {
 	return nil
 }
 
-func writeCredConfig(out *output.Context, path, execPath string) error {
-	out.Step("Writing Workforce Identity credential config")
-	data, err := buildCredConfig(execPath)
-	if err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return fmt.Errorf("failed to create gcloud config directory: %w", err)
-	}
-	if err := os.WriteFile(path, data, 0o644); err != nil {
-		return fmt.Errorf("failed to write credential config: %w", err)
-	}
-	return nil
-}
-
-// buildCredConfig renders the external_account credential config that points
-// gcloud at the credential helper.
-func buildCredConfig(execPath string) ([]byte, error) {
-	cfg := map[string]any{
-		"type": "external_account",
-		"audience": fmt.Sprintf(
-			"//iam.googleapis.com/locations/global/workforcePools/%s/providers/%s",
-			workforcePool, workforceProvider),
-		"subject_token_type":          "urn:ietf:params:oauth:token-type:id_token",
-		"token_url":                   "https://sts.googleapis.com/v1/token",
-		"workforce_pool_user_project": quotaProject,
-		"credential_source": map[string]any{
-			"executable": map[string]any{
-				"command":        execPath,
-				"timeout_millis": 10000,
-			},
-		},
-	}
-	data, err := json.MarshalIndent(cfg, "", "  ")
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal credential config: %w", err)
-	}
-	return append(data, '\n'), nil
-}
-
-// refreshTokenValid reports whether the helper can already mint a token, i.e.
-// a usable refresh token is present and no interactive login is required.
-func refreshTokenValid(execPath string) bool {
-	output, err := exec.Command(execPath).Output()
-	if err != nil {
-		return false
-	}
-	return bytes.Contains(output, []byte(`"success":true`))
+// sessionValid reports whether the helper can already mint a token from a stored
+// refresh token, i.e. no interactive login is required.
+func sessionValid(execPath string) bool {
+	return exec.Command(execPath, "--check").Run() == nil
 }
 
 func deviceLogin(execPath string) error {
@@ -144,19 +79,5 @@ func deviceLogin(execPath string) error {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	return cmd.Run()
-}
-
-func activateCredential(out *output.Context, credConfig string) error {
-	cmd := exec.Command("gcloud", "auth", "login", "--cred-file="+credConfig, "--quiet")
-	cmd.Env = append(os.Environ(), allowExecutables)
-	cmd.Stdout = out.MultiWriter(nil)
-	cmd.Stderr = out.MultiWriter(nil)
-	return cmd.Run()
-}
-
-func verifyCredential() error {
-	cmd := exec.Command("gcloud", "auth", "print-access-token")
-	cmd.Env = append(os.Environ(), allowExecutables)
 	return cmd.Run()
 }

--- a/nixpkgs/modac-dev-machine/internal/provision/gcloudworkforcelogin/gcloudworkforcelogin.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/gcloudworkforcelogin/gcloudworkforcelogin.go
@@ -1,6 +1,9 @@
 package gcloudworkforcelogin
 
 import (
+	"bytes"
+	_ "embed"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -10,19 +13,34 @@ import (
 	"github.com/modell-aachen/machine/internal/platform"
 )
 
-// Workforce Identity Federation pool and provider that back GKE cluster
-// authentication. Identity Service for GKE is discontinued on 2026-07-01;
-// afterwards kubectl authenticates via gke-gcloud-auth-plugin, which obtains a
-// token from the active gcloud credential. This module makes that credential a
-// Workforce Identity (federated via Azure AD) instead of a Google account.
+// ariadne-gcp-workforce-login is shipped with the binary and installed into the
+// user's PATH. It mints fresh Azure AD id_tokens from a stored refresh token so
+// GKE sees current group memberships on every token refresh.
+//
+//go:embed ariadne-gcp-workforce-login
+var execScript []byte
+
+// Workforce Identity Federation, federated via Azure AD, backs GKE cluster
+// authentication (Identity Service for GKE is discontinued on 2026-07-01).
+// Instead of a browser sign-in that freezes the group set until the next login,
+// we configure an executable-sourced external_account credential: gke-gcloud-
+// auth-plugin obtains a token from gcloud, gcloud re-runs the executable on
+// every STS refresh, and the executable re-mints an Azure id_token whose
+// `groups` claim reflects current (incl. JIT-activated) memberships.
 const (
 	workforcePool     = "ariadne-workforce"
 	workforceProvider = "ariadne-workforce"
+	// quotaProject attributes API quota/billing for the org-wide workforce
+	// identity's calls; the principal needs serviceusage.services.use on it.
+	quotaProject = "modac-dev"
+	execName     = "ariadne-gcp-workforce-login"
+	// allowExecutables is gcloud's security gate for executable-sourced creds.
+	allowExecutables = "GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES=1"
 )
 
-// Run configures gcloud for Workforce Identity Federation and signs the user
-// in, so that gke-gcloud-auth-plugin can obtain GKE tokens with no further
-// manual setup.
+// Run installs the credential helper, writes the credential config, ensures a
+// valid Azure refresh token (one-time interactive device-code login), and
+// activates the credential so gke-gcloud-auth-plugin can obtain GKE tokens.
 func Run(out *output.Context, plat platform.Platform) error {
 	_ = plat
 
@@ -30,49 +48,115 @@ func Run(out *output.Context, plat platform.Platform) error {
 	if err != nil {
 		return fmt.Errorf("failed to determine home directory: %w", err)
 	}
-	loginConfig := filepath.Join(home, ".config", "gcloud", "ariadne-login-config.json")
+	execPath := filepath.Join(home, ".local", "bin", execName)
+	credConfig := filepath.Join(home, ".config", "gcloud", "ariadne-cred-config.json")
 
-	// 1. Generate the (non-secret) login config describing the workforce pool
-	//    provider, unless it already exists. This must succeed without an active
-	//    credential, since it is a prerequisite for signing in.
-	if _, statErr := os.Stat(loginConfig); statErr != nil {
-		out.Step("Generating Workforce Identity login config")
-		provider := fmt.Sprintf("locations/global/workforcePools/%s/providers/%s", workforcePool, workforceProvider)
-		genCmd := exec.Command("gcloud", "iam", "workforce-pools", "create-login-config",
-			provider, "--output-file="+loginConfig)
-		genCmd.Stdout = out.MultiWriter(nil)
-		genCmd.Stderr = out.MultiWriter(nil)
-		if err := genCmd.Run(); err != nil {
-			return fmt.Errorf("failed to create workforce login config: %w", err)
-		}
+	if err := installExecutable(out, execPath); err != nil {
+		return err
+	}
+	if err := writeCredConfig(out, credConfig, execPath); err != nil {
+		return err
+	}
+
+	if refreshTokenValid(execPath) {
+		out.Skipped("Azure refresh token already valid")
 	} else {
-		out.Skipped("Workforce login config already present")
+		out.Step("Logging into Azure AD via device code (interactive, one-time)")
+		if err := deviceLogin(execPath); err != nil {
+			return fmt.Errorf("failed to obtain Azure refresh token: %w", err)
+		}
 	}
 
-	// 2. Make gcloud use the workforce login config for browser sign-in, so a
-	//    plain `gcloud auth login` runs the Workforce (Azure AD) flow.
-	out.Step("Configuring gcloud to use the Workforce login config")
-	setCmd := exec.Command("gcloud", "config", "set", "auth/login_config_file", loginConfig)
-	setCmd.Stdout = out.MultiWriter(nil)
-	setCmd.Stderr = out.MultiWriter(nil)
-	if err := setCmd.Run(); err != nil {
-		return fmt.Errorf("failed to set gcloud login config: %w", err)
+	out.Step("Activating the Workforce Identity credential for gcloud")
+	if err := activateCredential(out, credConfig); err != nil {
+		return fmt.Errorf("failed to activate workforce credential: %w", err)
 	}
-
-	// 3. Sign in if there is no active credential yet (interactive browser flow).
-	if err := exec.Command("gcloud", "auth", "print-access-token").Run(); err == nil {
-		out.Skipped("gcloud already has an active credential")
-		return nil
-	}
-
-	out.Step("Logging into Google Cloud via Workforce Identity (interactive)")
-	loginCmd := exec.Command("gcloud", "auth", "login")
-	loginCmd.Stdout = os.Stdout
-	loginCmd.Stderr = os.Stderr
-	loginCmd.Stdin = os.Stdin
-	if err := loginCmd.Run(); err != nil {
-		return fmt.Errorf("failed to authenticate to Google Cloud: %w", err)
+	if err := verifyCredential(); err != nil {
+		return fmt.Errorf("workforce credential is not usable: %w", err)
 	}
 
 	return nil
+}
+
+func installExecutable(out *output.Context, execPath string) error {
+	out.Step("Installing " + execName)
+	if err := os.MkdirAll(filepath.Dir(execPath), 0o755); err != nil {
+		return fmt.Errorf("failed to create bin directory: %w", err)
+	}
+	if err := os.WriteFile(execPath, execScript, 0o755); err != nil {
+		return fmt.Errorf("failed to write %s: %w", execName, err)
+	}
+	return nil
+}
+
+func writeCredConfig(out *output.Context, path, execPath string) error {
+	out.Step("Writing Workforce Identity credential config")
+	data, err := buildCredConfig(execPath)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("failed to create gcloud config directory: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("failed to write credential config: %w", err)
+	}
+	return nil
+}
+
+// buildCredConfig renders the external_account credential config that points
+// gcloud at the credential helper.
+func buildCredConfig(execPath string) ([]byte, error) {
+	cfg := map[string]any{
+		"type": "external_account",
+		"audience": fmt.Sprintf(
+			"//iam.googleapis.com/locations/global/workforcePools/%s/providers/%s",
+			workforcePool, workforceProvider),
+		"subject_token_type":          "urn:ietf:params:oauth:token-type:id_token",
+		"token_url":                   "https://sts.googleapis.com/v1/token",
+		"workforce_pool_user_project": quotaProject,
+		"credential_source": map[string]any{
+			"executable": map[string]any{
+				"command":        execPath,
+				"timeout_millis": 10000,
+			},
+		},
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal credential config: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
+// refreshTokenValid reports whether the helper can already mint a token, i.e.
+// a usable refresh token is present and no interactive login is required.
+func refreshTokenValid(execPath string) bool {
+	output, err := exec.Command(execPath).Output()
+	if err != nil {
+		return false
+	}
+	return bytes.Contains(output, []byte(`"success":true`))
+}
+
+func deviceLogin(execPath string) error {
+	cmd := exec.Command(execPath, "--login")
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func activateCredential(out *output.Context, credConfig string) error {
+	cmd := exec.Command("gcloud", "auth", "login", "--cred-file="+credConfig, "--quiet")
+	cmd.Env = append(os.Environ(), allowExecutables)
+	cmd.Stdout = out.MultiWriter(nil)
+	cmd.Stderr = out.MultiWriter(nil)
+	return cmd.Run()
+}
+
+func verifyCredential() error {
+	cmd := exec.Command("gcloud", "auth", "print-access-token")
+	cmd.Env = append(os.Environ(), allowExecutables)
+	return cmd.Run()
 }

--- a/nixpkgs/modac-dev-machine/internal/provision/gcloudworkforcelogin/gcloudworkforcelogin.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/gcloudworkforcelogin/gcloudworkforcelogin.go
@@ -1,6 +1,7 @@
 package gcloudworkforcelogin
 
 import (
+	"bytes"
 	_ "embed"
 	"fmt"
 	"os"
@@ -44,7 +45,14 @@ func Run(out *output.Context, plat platform.Platform) error {
 		return err
 	}
 
-	if sessionValid(execPath) {
+	if hasSession(execPath) {
+		// A refresh token exists; validate the full path (Azure + STS) so a
+		// broken exchange surfaces here instead of on the first kubectl, and is
+		// not mistaken for "needs login".
+		if err := checkSession(execPath); err != nil {
+			return fmt.Errorf("workforce session present but token exchange failed; "+
+				"check QUOTA_PROJECT/serviceusage and the provider audience: %w", err)
+		}
 		out.Skipped("Workforce session already valid")
 		return nil
 	}
@@ -52,6 +60,10 @@ func Run(out *output.Context, plat platform.Platform) error {
 	out.Step("Logging into Azure AD via device code (interactive, one-time)")
 	if err := deviceLogin(execPath); err != nil {
 		return fmt.Errorf("failed to obtain Azure refresh token: %w", err)
+	}
+	if err := checkSession(execPath); err != nil {
+		return fmt.Errorf("token exchange failed after login; "+
+			"check QUOTA_PROJECT/serviceusage and the provider audience: %w", err)
 	}
 
 	return nil
@@ -68,10 +80,19 @@ func installExecutable(out *output.Context, execPath string) error {
 	return nil
 }
 
-// sessionValid reports whether the helper can already mint a token from a stored
-// refresh token, i.e. no interactive login is required.
-func sessionValid(execPath string) bool {
-	return exec.Command(execPath, "--check").Run() == nil
+// hasSession reports whether a refresh token is present (no network call).
+func hasSession(execPath string) bool {
+	return exec.Command(execPath, "--has-session").Run() == nil
+}
+
+// checkSession validates the full credential path (Azure refresh + STS
+// exchange), surfacing the helper's error message on failure.
+func checkSession(execPath string) error {
+	out, err := exec.Command(execPath, "--check").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%w: %s", err, bytes.TrimSpace(out))
+	}
+	return nil
 }
 
 func deviceLogin(execPath string) error {

--- a/nixpkgs/modac-dev-machine/internal/provision/gcloudworkforcelogin/gcloudworkforcelogin_test.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/gcloudworkforcelogin/gcloudworkforcelogin_test.go
@@ -1,0 +1,66 @@
+package gcloudworkforcelogin
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestBuildCredConfig(t *testing.T) {
+	const execPath = "/home/dev/.local/bin/ariadne-gcp-workforce-login"
+
+	data, err := buildCredConfig(execPath)
+	if err != nil {
+		t.Fatalf("buildCredConfig returned error: %v", err)
+	}
+
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("credential config is not valid JSON: %v", err)
+	}
+
+	if cfg["type"] != "external_account" {
+		t.Errorf("type = %v, want external_account", cfg["type"])
+	}
+	if cfg["subject_token_type"] != "urn:ietf:params:oauth:token-type:id_token" {
+		t.Errorf("subject_token_type = %v", cfg["subject_token_type"])
+	}
+	if cfg["workforce_pool_user_project"] != quotaProject {
+		t.Errorf("workforce_pool_user_project = %v, want %s", cfg["workforce_pool_user_project"], quotaProject)
+	}
+
+	audience, _ := cfg["audience"].(string)
+	if !strings.Contains(audience, workforcePool) || !strings.Contains(audience, workforceProvider) {
+		t.Errorf("audience %q does not reference pool/provider", audience)
+	}
+
+	source, ok := cfg["credential_source"].(map[string]any)
+	if !ok {
+		t.Fatalf("credential_source missing or wrong type")
+	}
+	executable, ok := source["executable"].(map[string]any)
+	if !ok {
+		t.Fatalf("credential_source.executable missing or wrong type")
+	}
+	if executable["command"] != execPath {
+		t.Errorf("command = %v, want %s", executable["command"], execPath)
+	}
+}
+
+func TestEmbeddedExecutable(t *testing.T) {
+	if !bytes.HasPrefix(execScript, []byte("#!")) {
+		t.Error("embedded executable is missing a shebang")
+	}
+	for _, want := range []string{
+		"--login",
+		"--force-refresh",
+		"--logout",
+		"refresh_token",
+		"urn:ietf:params:oauth:token-type:id_token",
+	} {
+		if !bytes.Contains(execScript, []byte(want)) {
+			t.Errorf("embedded executable does not contain %q", want)
+		}
+	}
+}

--- a/nixpkgs/modac-dev-machine/internal/provision/gcloudworkforcelogin/gcloudworkforcelogin_test.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/gcloudworkforcelogin/gcloudworkforcelogin_test.go
@@ -13,6 +13,8 @@ func TestEmbeddedExecutable(t *testing.T) {
 		"get-token",
 		"ExecCredential",
 		"--login",
+		"--has-session",
+		"--check",
 		"--force-refresh",
 		"--logout",
 		"refresh_token",

--- a/nixpkgs/modac-dev-machine/internal/provision/gcloudworkforcelogin/gcloudworkforcelogin_test.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/gcloudworkforcelogin/gcloudworkforcelogin_test.go
@@ -2,62 +2,20 @@ package gcloudworkforcelogin
 
 import (
 	"bytes"
-	"encoding/json"
-	"strings"
 	"testing"
 )
-
-func TestBuildCredConfig(t *testing.T) {
-	const execPath = "/home/dev/.local/bin/ariadne-gcp-workforce-login"
-
-	data, err := buildCredConfig(execPath)
-	if err != nil {
-		t.Fatalf("buildCredConfig returned error: %v", err)
-	}
-
-	var cfg map[string]any
-	if err := json.Unmarshal(data, &cfg); err != nil {
-		t.Fatalf("credential config is not valid JSON: %v", err)
-	}
-
-	if cfg["type"] != "external_account" {
-		t.Errorf("type = %v, want external_account", cfg["type"])
-	}
-	if cfg["subject_token_type"] != "urn:ietf:params:oauth:token-type:id_token" {
-		t.Errorf("subject_token_type = %v", cfg["subject_token_type"])
-	}
-	if cfg["workforce_pool_user_project"] != quotaProject {
-		t.Errorf("workforce_pool_user_project = %v, want %s", cfg["workforce_pool_user_project"], quotaProject)
-	}
-
-	audience, _ := cfg["audience"].(string)
-	if !strings.Contains(audience, workforcePool) || !strings.Contains(audience, workforceProvider) {
-		t.Errorf("audience %q does not reference pool/provider", audience)
-	}
-
-	source, ok := cfg["credential_source"].(map[string]any)
-	if !ok {
-		t.Fatalf("credential_source missing or wrong type")
-	}
-	executable, ok := source["executable"].(map[string]any)
-	if !ok {
-		t.Fatalf("credential_source.executable missing or wrong type")
-	}
-	if executable["command"] != execPath {
-		t.Errorf("command = %v, want %s", executable["command"], execPath)
-	}
-}
 
 func TestEmbeddedExecutable(t *testing.T) {
 	if !bytes.HasPrefix(execScript, []byte("#!")) {
 		t.Error("embedded executable is missing a shebang")
 	}
 	for _, want := range []string{
+		"get-token",
+		"ExecCredential",
 		"--login",
 		"--force-refresh",
 		"--logout",
 		"refresh_token",
-		"urn:ietf:params:oauth:token-type:id_token",
 	} {
 		if !bytes.Contains(execScript, []byte(want)) {
 			t.Errorf("embedded executable does not contain %q", want)


### PR DESCRIPTION
## Summary

Ships `ariadne-gcp-workforce-login`, a **client-go exec credential plugin** that gives kubectl a GKE token from the user's Azure AD identity via Workforce Identity Federation — and re-evaluates the `groups` claim on every (cache-missing) refresh, so JIT/PIM group changes take effect **without a re-login** (refresh token valid ~90 days).

The plugin mints a fresh Azure AD id_token from a stored refresh token, exchanges it at Google STS for a federated access token, and prints an `ExecCredential`. gcloud is **not** on the runtime path, so no `GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES` gate is required anywhere. This restores the old kube-login behaviour (OIDC refresh-token grant against Azure) on the Workforce Identity pipeline that replaces Identity Service for GKE (EOL 2026-07-01).

## How it works

```
kubectl/k9s/Lens → ariadne-gcp-workforce-login get-token
                     ├─ Azure AD refresh_token grant → fresh id_token (current groups)
                     ├─ Google STS token exchange     → federated access token
                     └─ ExecCredential (cached ~1h)   → GKE
```

The helper prepends the devbox profile bin to its own PATH, so it resolves `curl`/`jq` even when launched by k9s/Lens/Finder with a minimal PATH (self-sufficient, no kubeconfig `exec.env` needed).

## Changes

- `ariadne-gcp-workforce-login`: new bash+jq exec credential plugin (`//go:embed`, installed to `~/.local/bin/`). Commands: `get-token`, `--login` (device code), `--force-refresh` (drop cached token → re-pull groups), `--logout`, `--help`.
- `gcloudworkforcelogin.go`: rewritten — installs the helper and does the one-time interactive device-code login. Browser flow and gcloud cred activation removed.
- `gcloudworkforcelogin_test.go`: embedded-helper tests.
- `plugin.json`: version 0.0.5 → 0.0.6 (no env-var changes).

## kubeconfig

The kubeconfig wiring the GKE users to the helper is **managed by the team in 1Password** (not generated by this module). Per-user `exec` stanza:

```yaml
users:
- name: <cluster>-wf
  user:
    exec:
      apiVersion: client.authentication.k8s.io/v1
      command: ariadne-gcp-workforce-login   # bare name, resolved via PATH (like gke-gcloud-auth-plugin)
      args: ["get-token"]
      interactiveMode: Never
      provideClusterInfo: false
```

The bare command name is OS/user-agnostic and matches the existing `gke-gcloud-auth-plugin` convention; `~/.local/bin` is on PATH via the devbox plugin.

## Dev experience

- First `machine provision`: one interactive device-code login.
- Refresh groups after a JIT activation: `ariadne-gcp-workforce-login --force-refresh && kubectl auth whoami`.

## Decisions / review points

- **Quota project** `QUOTA_PROJECT = modac-dev` (constant in the helper). Required so the org-wide workforce identity can attribute STS API quota/billing; the principal needs `serviceusage.services.use` on it.
- The Azure app `090c1876-…` must keep **"Allow public client flows"** enabled and emit the `groups` claim on the ID token.

## Rollback

Revert the commits and restore the previous kubeconfig (gke-gcloud-auth-plugin) from 1Password.

## Post-merge

Bump the plugin `rev` hash in the global devbox.json (CI `update-machine-hash`).
