### PR TITLE
fix: create gcloud config dir before writing token

### DIFF
--- a/nixpkgs/modac-dev-machine/internal/provision/gcloudworkforcelogin/ariadne-gcp-workforce-login
+++ b/nixpkgs/modac-dev-machine/internal/provision/gcloudworkforcelogin/ariadne-gcp-workforce-login
@@ -44,6 +44,7 @@ die() {
 
 write_secret() { # write_secret <file> <content>
   local tmp="$1.tmp"
+  mkdir -p "$(dirname "$1")" # the gcloud config dir may not exist yet on a fresh machine
   (umask 077; printf '%s' "$2" >"$tmp")
   mv -f "$1.tmp" "$1"
 }


### PR DESCRIPTION
## Summary

`ariadne-gcp-workforce-login --login` (and the token-cache write) failed on a fresh machine where `~/.config/gcloud` does not exist yet:

```
.../ariadne-azure-refresh-token.tmp: No such file or directory
✗ Module failed: failed to obtain Azure refresh token: exit status 1
```

`write_secret` wrote the temp file without ensuring its parent directory exists.

## Fix

`write_secret` now runs `mkdir -p "$(dirname "$1")"` before writing. This covers both the refresh-token file and the access-token cache, regardless of caller. The secret file itself stays `0600` (`umask 077`).

## Verification

- Isolated repro: `write_secret` into a non-existent `.config/gcloud` now creates the dir and writes the `0600` file.
- `shellcheck` clean, `go vet` / `go test` / `go build` green.
