### PR TITLE
feat: self-update and re-exec on provision

### DIFF
--- a/nixpkgs/modac-dev-machine/internal/provision/devboxupdate/devboxupdate.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/devboxupdate/devboxupdate.go
@@ -1,54 +1,34 @@
 package devboxupdate
 
 import (
-	"fmt"
 	"os"
-	"os/exec"
-	"syscall"
 
 	"github.com/modell-aachen/machine/internal/devbox"
 	"github.com/modell-aachen/machine/internal/output"
 	"github.com/modell-aachen/machine/internal/platform"
 )
 
-// selfUpdatedEnv guards against an infinite re-exec loop: it is set on the
-// process we exec into after updating, so the second pass skips the update.
-const selfUpdatedEnv = "MACHINE_SELF_UPDATED"
+// RestartGuardEnv guards against an infinite re-exec loop: the executor sets it
+// on the process it re-execs into after an update, so the second pass skips the
+// update instead of triggering another restart.
+const RestartGuardEnv = "MACHINE_SELF_UPDATED"
 
-// alreadyUpdated reports whether this process is the post-re-exec pass.
-func alreadyUpdated() bool {
-	return os.Getenv(selfUpdatedEnv) == "1"
+// AlreadyUpdated reports whether this process is the post-re-exec pass.
+func AlreadyUpdated() bool {
+	return os.Getenv(RestartGuardEnv) == "1"
 }
 
-// Run updates the devbox global environment and then, on the first pass, re-execs
-// the (possibly newer) machine binary so that modules added or changed by the
-// update run in the same `machine provision` invocation. The whole provision
-// restarts from the top under the new binary; modules are idempotent, so the few
-// that run before this one simply run again.
+// Run updates the devbox global environment. Restarting into a newer machine
+// binary (so modules added or changed by the update run in the same provision)
+// is the executor's job — see provision.Execute. On the post-re-exec pass this
+// skips, so a single `machine provision` never updates twice.
 func Run(out *output.Context, plat platform.Platform) error {
 	_ = plat
 
-	if alreadyUpdated() {
+	if AlreadyUpdated() {
 		out.Skipped("devbox already updated earlier this run")
 		return nil
 	}
 
-	if err := devbox.GlobalUpdate(out); err != nil {
-		return err
-	}
-
-	// Restart into whatever machine is now on PATH so the rest of provisioning
-	// uses the updated binary. devbox.GlobalUpdate already refreshed PATH into
-	// this process's env, which os.Environ() carries to the new image.
-	bin, err := exec.LookPath("machine")
-	if err != nil {
-		// machine not resolvable on PATH; continue with the current binary.
-		return nil
-	}
-
-	out.Step("Restarting machine with the updated environment")
-	if err := syscall.Exec(bin, os.Args, append(os.Environ(), selfUpdatedEnv+"=1")); err != nil {
-		return fmt.Errorf("failed to restart machine after update: %w", err)
-	}
-	return nil // unreachable on success: syscall.Exec replaces the process image
+	return devbox.GlobalUpdate(out)
 }

--- a/nixpkgs/modac-dev-machine/internal/provision/devboxupdate/devboxupdate.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/devboxupdate/devboxupdate.go
@@ -8,20 +8,12 @@ import (
 	"github.com/modell-aachen/machine/internal/platform"
 )
 
-// RestartGuardEnv guards against an infinite re-exec loop: the executor sets it
-// on the process it re-execs into after an update, so the second pass skips the
-// update instead of triggering another restart.
 const RestartGuardEnv = "MACHINE_SELF_UPDATED"
 
-// AlreadyUpdated reports whether this process is the post-re-exec pass.
 func AlreadyUpdated() bool {
 	return os.Getenv(RestartGuardEnv) == "1"
 }
 
-// Run updates the devbox global environment. Restarting into a newer machine
-// binary (so modules added or changed by the update run in the same provision)
-// is the executor's job — see provision.Execute. On the post-re-exec pass this
-// skips, so a single `machine provision` never updates twice.
 func Run(out *output.Context, plat platform.Platform) error {
 	_ = plat
 

--- a/nixpkgs/modac-dev-machine/internal/provision/devboxupdate/devboxupdate.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/devboxupdate/devboxupdate.go
@@ -1,13 +1,54 @@
 package devboxupdate
 
 import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+
 	"github.com/modell-aachen/machine/internal/devbox"
 	"github.com/modell-aachen/machine/internal/output"
 	"github.com/modell-aachen/machine/internal/platform"
 )
 
-// Run updates the devbox global environment
+// selfUpdatedEnv guards against an infinite re-exec loop: it is set on the
+// process we exec into after updating, so the second pass skips the update.
+const selfUpdatedEnv = "MACHINE_SELF_UPDATED"
+
+// alreadyUpdated reports whether this process is the post-re-exec pass.
+func alreadyUpdated() bool {
+	return os.Getenv(selfUpdatedEnv) == "1"
+}
+
+// Run updates the devbox global environment and then, on the first pass, re-execs
+// the (possibly newer) machine binary so that modules added or changed by the
+// update run in the same `machine provision` invocation. The whole provision
+// restarts from the top under the new binary; modules are idempotent, so the few
+// that run before this one simply run again.
 func Run(out *output.Context, plat platform.Platform) error {
 	_ = plat
-	return devbox.GlobalUpdate(out)
+
+	if alreadyUpdated() {
+		out.Skipped("devbox already updated earlier this run")
+		return nil
+	}
+
+	if err := devbox.GlobalUpdate(out); err != nil {
+		return err
+	}
+
+	// Restart into whatever machine is now on PATH so the rest of provisioning
+	// uses the updated binary. devbox.GlobalUpdate already refreshed PATH into
+	// this process's env, which os.Environ() carries to the new image.
+	bin, err := exec.LookPath("machine")
+	if err != nil {
+		// machine not resolvable on PATH; continue with the current binary.
+		return nil
+	}
+
+	out.Step("Restarting machine with the updated environment")
+	if err := syscall.Exec(bin, os.Args, append(os.Environ(), selfUpdatedEnv+"=1")); err != nil {
+		return fmt.Errorf("failed to restart machine after update: %w", err)
+	}
+	return nil // unreachable on success: syscall.Exec replaces the process image
 }

--- a/nixpkgs/modac-dev-machine/internal/provision/devboxupdate/devboxupdate_test.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/devboxupdate/devboxupdate_test.go
@@ -4,16 +4,16 @@ import "testing"
 
 func TestAlreadyUpdated(t *testing.T) {
 	t.Run("unset means not yet updated", func(t *testing.T) {
-		t.Setenv(selfUpdatedEnv, "")
-		if alreadyUpdated() {
-			t.Error("alreadyUpdated() = true with the guard unset, want false")
+		t.Setenv(RestartGuardEnv, "")
+		if AlreadyUpdated() {
+			t.Error("AlreadyUpdated() = true with the guard unset, want false")
 		}
 	})
 
 	t.Run("set to 1 means already updated", func(t *testing.T) {
-		t.Setenv(selfUpdatedEnv, "1")
-		if !alreadyUpdated() {
-			t.Error("alreadyUpdated() = false with the guard set, want true")
+		t.Setenv(RestartGuardEnv, "1")
+		if !AlreadyUpdated() {
+			t.Error("AlreadyUpdated() = false with the guard set, want true")
 		}
 	})
 }

--- a/nixpkgs/modac-dev-machine/internal/provision/devboxupdate/devboxupdate_test.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/devboxupdate/devboxupdate_test.go
@@ -1,0 +1,19 @@
+package devboxupdate
+
+import "testing"
+
+func TestAlreadyUpdated(t *testing.T) {
+	t.Run("unset means not yet updated", func(t *testing.T) {
+		t.Setenv(selfUpdatedEnv, "")
+		if alreadyUpdated() {
+			t.Error("alreadyUpdated() = true with the guard unset, want false")
+		}
+	})
+
+	t.Run("set to 1 means already updated", func(t *testing.T) {
+		t.Setenv(selfUpdatedEnv, "1")
+		if !alreadyUpdated() {
+			t.Error("alreadyUpdated() = false with the guard set, want true")
+		}
+	})
+}

--- a/nixpkgs/modac-dev-machine/internal/provision/executor.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/executor.go
@@ -2,7 +2,11 @@ package provision
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/modell-aachen/machine/internal/output"
 	"github.com/modell-aachen/machine/internal/platform"
@@ -40,10 +44,18 @@ type ModuleEntry struct {
 	Runner func(*output.Context, platform.Platform) error
 }
 
-// allModules defines the ordered list of all provisioning modules
+// devboxUpdateModuleName is the module after which the executor may re-exec into
+// a newly installed machine binary (see reexecAfterUpdate).
+const devboxUpdateModuleName = "devbox-update"
+
+// allModules defines the ordered list of all provisioning modules.
+//
+// Every module listed before devboxUpdateModuleName must be idempotent: when an
+// update installs a newer binary, the executor re-execs and the provision runs
+// from the top again on the new binary, so those modules run twice.
 var allModules = []ModuleEntry{
 	{"nix-conf", nixconf.Run},
-	{"devbox-update", devboxupdate.Run},
+	{devboxUpdateModuleName, devboxupdate.Run},
 	{"onepassword", onepassword.Run},
 	{"restore-backup", restorebackup.Run},
 	{"packages", packages.Run},
@@ -114,16 +126,84 @@ func Execute(opts *Options) error {
 
 	modules := FilterModules(opts.Filter)
 
+	// Resolved path of the binary we're running. After devbox-update we compare
+	// it against the machine now on PATH and re-exec if it changed, so the rest
+	// of the modules run on the updated binary.
+	self := currentBinary()
+
 	// Run all modules
 	for _, module := range modules {
 		if err := runModule(out, module, plat); err != nil {
 			out.PrintError(fmt.Errorf("module %s failed: %w", module.Name, err))
 			return fmt.Errorf("module %s failed: %w", module.Name, err)
 		}
+		if module.Name == devboxUpdateModuleName {
+			if err := reexecAfterUpdate(out, self); err != nil {
+				out.PrintError(err)
+				return err
+			}
+		}
 	}
 
 	out.PrintSummary()
 	return nil
+}
+
+// currentBinary returns the resolved path of the running machine binary, or ""
+// if it can't be determined. An empty result makes reexecAfterUpdate treat the
+// post-update binary as changed — better to reload than to silently keep running
+// a possibly stale binary.
+func currentBinary() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		return resolved
+	}
+	return exe
+}
+
+// binaryChanged reports whether resolved is a different machine binary than the
+// one currently running (self). An unresolvable resolved ("") counts as no
+// change so the caller keeps running rather than re-exec into nothing.
+func binaryChanged(self, resolved string) bool {
+	return resolved != "" && resolved != self
+}
+
+// reexecAfterUpdate restarts the provision under the machine binary now on PATH
+// when devbox-update installed a different one, so the remaining modules run on
+// it. devbox.GlobalUpdate already refreshed PATH into this process's env, which
+// os.Environ() carries to the new image. The RestartGuardEnv guard makes the
+// post-re-exec pass a no-op here, so this cannot loop. On success it never
+// returns — syscall.Exec replaces the process image.
+func reexecAfterUpdate(out *output.Context, self string) error {
+	if devboxupdate.AlreadyUpdated() {
+		return nil
+	}
+
+	bin, err := exec.LookPath("machine")
+	if err != nil {
+		out.Skipped("machine not found on PATH after update; continuing on the current binary")
+		return nil
+	}
+
+	resolved, err := filepath.EvalSymlinks(bin)
+	if err != nil {
+		resolved = bin
+	}
+
+	if !binaryChanged(self, resolved) {
+		out.Skipped("machine binary unchanged; no restart needed")
+		return nil
+	}
+
+	out.Step("Restarting machine with the updated binary")
+	env := append(os.Environ(), devboxupdate.RestartGuardEnv+"=1")
+	if err := syscall.Exec(bin, os.Args, env); err != nil {
+		return fmt.Errorf("failed to restart machine after update: %w", err)
+	}
+	return nil // unreachable on success: syscall.Exec replaces the process image
 }
 
 func ListModules() error {

--- a/nixpkgs/modac-dev-machine/internal/provision/executor.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/executor.go
@@ -44,15 +44,8 @@ type ModuleEntry struct {
 	Runner func(*output.Context, platform.Platform) error
 }
 
-// devboxUpdateModuleName is the module after which the executor may re-exec into
-// a newly installed machine binary (see reexecAfterUpdate).
 const devboxUpdateModuleName = "devbox-update"
 
-// allModules defines the ordered list of all provisioning modules.
-//
-// Every module listed before devboxUpdateModuleName must be idempotent: when an
-// update installs a newer binary, the executor re-execs and the provision runs
-// from the top again on the new binary, so those modules run twice.
 var allModules = []ModuleEntry{
 	{"nix-conf", nixconf.Run},
 	{devboxUpdateModuleName, devboxupdate.Run},
@@ -126,12 +119,8 @@ func Execute(opts *Options) error {
 
 	modules := FilterModules(opts.Filter)
 
-	// Resolved path of the binary we're running. After devbox-update we compare
-	// it against the machine now on PATH and re-exec if it changed, so the rest
-	// of the modules run on the updated binary.
 	self := currentBinary()
 
-	// Run all modules
 	for _, module := range modules {
 		if err := runModule(out, module, plat); err != nil {
 			out.PrintError(fmt.Errorf("module %s failed: %w", module.Name, err))
@@ -149,10 +138,6 @@ func Execute(opts *Options) error {
 	return nil
 }
 
-// currentBinary returns the resolved path of the running machine binary, or ""
-// if it can't be determined. An empty result makes reexecAfterUpdate treat the
-// post-update binary as changed — better to reload than to silently keep running
-// a possibly stale binary.
 func currentBinary() string {
 	exe, err := os.Executable()
 	if err != nil {
@@ -164,19 +149,10 @@ func currentBinary() string {
 	return exe
 }
 
-// binaryChanged reports whether resolved is a different machine binary than the
-// one currently running (self). An unresolvable resolved ("") counts as no
-// change so the caller keeps running rather than re-exec into nothing.
 func binaryChanged(self, resolved string) bool {
 	return resolved != "" && resolved != self
 }
 
-// reexecAfterUpdate restarts the provision under the machine binary now on PATH
-// when devbox-update installed a different one, so the remaining modules run on
-// it. devbox.GlobalUpdate already refreshed PATH into this process's env, which
-// os.Environ() carries to the new image. The RestartGuardEnv guard makes the
-// post-re-exec pass a no-op here, so this cannot loop. On success it never
-// returns — syscall.Exec replaces the process image.
 func reexecAfterUpdate(out *output.Context, self string) error {
 	if devboxupdate.AlreadyUpdated() {
 		return nil
@@ -203,7 +179,7 @@ func reexecAfterUpdate(out *output.Context, self string) error {
 	if err := syscall.Exec(bin, os.Args, env); err != nil {
 		return fmt.Errorf("failed to restart machine after update: %w", err)
 	}
-	return nil // unreachable on success: syscall.Exec replaces the process image
+	return nil
 }
 
 func ListModules() error {

--- a/nixpkgs/modac-dev-machine/internal/provision/executor.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/executor.go
@@ -38,7 +38,6 @@ type Options struct {
 	Filter string
 }
 
-// ModuleEntry represents a provisioning module with its name and runner function
 type ModuleEntry struct {
 	Name   string
 	Runner func(*output.Context, platform.Platform) error
@@ -71,7 +70,6 @@ var allModules = []ModuleEntry{
 	{"docker", docker.Run},
 }
 
-// GetAllModuleNames returns the names of all available modules
 func GetAllModuleNames() []string {
 	names := make([]string, len(allModules))
 	for i, module := range allModules {
@@ -80,7 +78,6 @@ func GetAllModuleNames() []string {
 	return names
 }
 
-// FilterModules returns a filtered list of modules based on the filter string
 func FilterModules(filter string) []ModuleEntry {
 	if filter == "" {
 		return allModules
@@ -102,7 +99,6 @@ func FilterModules(filter string) []ModuleEntry {
 }
 
 func Execute(opts *Options) error {
-	// Create output context for nice formatting and logging
 	out, err := output.New()
 	if err != nil {
 		return fmt.Errorf("failed to initialize output: %w", err)

--- a/nixpkgs/modac-dev-machine/internal/provision/executor_test.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/executor_test.go
@@ -1,0 +1,25 @@
+package provision
+
+import "testing"
+
+func TestBinaryChanged(t *testing.T) {
+	tests := []struct {
+		name     string
+		self     string
+		resolved string
+		want     bool
+	}{
+		{"same path means unchanged", "/nix/store/aaa/bin/machine", "/nix/store/aaa/bin/machine", false},
+		{"different path means changed", "/nix/store/aaa/bin/machine", "/nix/store/bbb/bin/machine", true},
+		{"unresolvable post-update binary counts as unchanged", "/nix/store/aaa/bin/machine", "", false},
+		{"unknown current binary forces a reload", "", "/nix/store/bbb/bin/machine", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := binaryChanged(tt.self, tt.resolved); got != tt.want {
+				t.Errorf("binaryChanged(%q, %q) = %v, want %v", tt.self, tt.resolved, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`machine provision` now picks up modules added or changed by a devbox global update **in the same run**, instead of requiring a second `machine provision`.

Previously the `devbox-update` module updated the global environment, but the rest of provisioning kept running the **old** `machine` binary — so newly added/changed modules only took effect on the next invocation.

## How it works

The `devbox-update` module only updates the devbox global environment. The provision **executor** owns the restart: right after `devbox-update` runs, it compares the binary it's currently running against the `machine` now resolvable on the (refreshed) `PATH`, and re-execs only if it actually changed.

```
pass 1 (old binary): nix-conf → devbox-update → devbox global update
                     → executor: binary changed? → syscall.Exec(machine, args, MACHINE_SELF_UPDATED=1)
pass 2 (new binary): nix-conf → devbox-update (guard set → skip)
                     → executor: binary unchanged → no restart → rest of modules run on the new binary
```

- **Re-exec only when the binary changed.** The executor records the resolved path of the running binary up front (`os.Executable` → `EvalSymlinks`) and compares it to the post-update `machine` on `PATH`. An already-current provision does **not** restart — no duplicate run, no second log. If the current binary can't be resolved, it reloads anyway (safer than silently running stale).
- **Restart lives in the executor, not the module.** `devbox-update` keeps its single responsibility (update the global env); process lifecycle is the orchestrator's job. `devbox.GlobalUpdate` already refreshed `PATH` into this process's env, which `os.Environ()` carries to the new image.
- **Cannot loop.** An env guard (`MACHINE_SELF_UPDATED=1`) is set on the re-exec'd process; the second pass skips the update and the executor's restart check is a no-op.
- The provision restarts from the top under the new binary. Modules listed before `devbox-update` (currently only `nix-conf`) must be idempotent, since they run again on the second pass.
- Targeted runs that don't include `devbox-update` (`-f <module>`) are unaffected.
- `output` writes unbuffered to the log file, so no flush is needed before `syscall.Exec` replaces the process image.

## Notes

- The benefit applies from the run **after** the new binary is installed (you can't get new behaviour before the new code exists). From then on it's one update + (only if the binary moved) one re-exec per full provision.
- On a genuine update the re-exec'd pass opens a fresh log file, so that update produces two `provision-<timestamp>.log` files; the pre-restart log isn't given its `Finished at:` footer. No log data is lost. Cosmetic.
- Unix-only (`syscall.Exec`), matching the supported platforms (macOS/Ubuntu).

## Verification

- `gofmt` / `go vet ./...` / `go test ./...` / `go build` green (run locally; the repo has no build/test CI).
- `TestAlreadyUpdated` covers the re-exec loop guard.
- `TestBinaryChanged` covers the changed-binary decision (same path → no restart, different path → restart, unresolvable post-update binary → no restart, unknown current binary → reload).