### PR TITLE
Provision claude-skills marketplace via claude module

### DIFF
--- a/nixpkgs/modac-dev-machine/internal/provision/claude/claude.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/claude/claude.go
@@ -35,6 +35,10 @@ func Run(out *output.Context, plat platform.Platform) error {
 		return err
 	}
 
+	if err := setupPlugins(out, claudeDir); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -136,6 +140,84 @@ func setupMcpConfig(out *output.Context, claudeDir string) error {
 	return nil
 }
 
+func setupPlugins(out *output.Context, claudeDir string) error {
+	templatesDir, err := util.GetTemplatesDir()
+	if err != nil {
+		return fmt.Errorf("failed to find templates directory: %w", err)
+	}
+
+	templatePath := filepath.Join(templatesDir, "claude-plugins.json")
+	templateData, err := os.ReadFile(templatePath)
+	if err != nil {
+		return fmt.Errorf("failed to read plugins template: %w", err)
+	}
+
+	var template map[string]any
+	if err := json.Unmarshal(templateData, &template); err != nil {
+		return fmt.Errorf("failed to parse plugins template: %w", err)
+	}
+
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+
+	var settings map[string]any
+	if util.FileExists(settingsPath) {
+		data, err := os.ReadFile(settingsPath)
+		if err != nil {
+			return fmt.Errorf("failed to read claude settings: %w", err)
+		}
+		if err := json.Unmarshal(data, &settings); err != nil {
+			return fmt.Errorf("failed to parse claude settings: %w", err)
+		}
+	} else {
+		settings = map[string]any{}
+	}
+
+	added := mergePluginSettings(settings, template)
+	if added == 0 {
+		out.Skipped("Plugin marketplace and plugins already configured")
+		return nil
+	}
+
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal claude settings: %w", err)
+	}
+
+	out.Step(fmt.Sprintf("Adding %d plugin setting(s) to ~/.claude/settings.json", added))
+	if err := os.WriteFile(settingsPath, append(data, '\n'), 0644); err != nil {
+		return fmt.Errorf("failed to write claude settings: %w", err)
+	}
+
+	return nil
+}
+
+// mergePluginSettings adds the marketplace and plugin entries from template into
+// settings without overwriting existing keys, so a user's own overrides survive
+// re-provisioning. It returns the number of entries added.
+func mergePluginSettings(settings, template map[string]any) int {
+	added := 0
+	for _, key := range []string{"extraKnownMarketplaces", "enabledPlugins"} {
+		templateEntries, ok := template[key].(map[string]any)
+		if !ok {
+			continue
+		}
+
+		existing, ok := settings[key].(map[string]any)
+		if !ok {
+			existing = map[string]any{}
+		}
+
+		for name, value := range templateEntries {
+			if _, exists := existing[name]; !exists {
+				existing[name] = value
+				added++
+			}
+		}
+
+		settings[key] = existing
+	}
+	return added
+}
 
 func copyFile(src, dst string) error {
 	sourceFile, err := os.Open(src)

--- a/nixpkgs/modac-dev-machine/internal/provision/claude/claude_test.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/claude/claude_test.go
@@ -1,0 +1,143 @@
+package claude
+
+import (
+	"reflect"
+	"testing"
+)
+
+func template() map[string]any {
+	return map[string]any{
+		"extraKnownMarketplaces": map[string]any{
+			"claude-skills": map[string]any{
+				"source":     map[string]any{"source": "github", "repo": "modell-aachen/claude-skills"},
+				"autoUpdate": true,
+			},
+		},
+		"enabledPlugins": map[string]any{
+			"dev-workflow@claude-skills": true,
+		},
+	}
+}
+
+func TestMergePluginSettings(t *testing.T) {
+	tests := []struct {
+		name      string
+		settings  map[string]any
+		wantAdded int
+		wantKeep  map[string]bool // enabledPlugins keys that must remain enabled
+	}{
+		{
+			name:      "empty settings gets marketplace and plugin",
+			settings:  map[string]any{},
+			wantAdded: 2,
+			wantKeep:  map[string]bool{"dev-workflow@claude-skills": true},
+		},
+		{
+			name: "preserves unrelated enabled plugins and marketplaces",
+			settings: map[string]any{
+				"enabledPlugins": map[string]any{
+					"typescript-lsp@claude-plugins-official": true,
+				},
+			},
+			wantAdded: 2,
+			wantKeep: map[string]bool{
+				"typescript-lsp@claude-plugins-official": true,
+				"dev-workflow@claude-skills":             true,
+			},
+		},
+		{
+			name: "marketplace present but plugin missing adds only the plugin",
+			settings: map[string]any{
+				"extraKnownMarketplaces": map[string]any{
+					"claude-skills": map[string]any{"source": map[string]any{}},
+				},
+			},
+			wantAdded: 1,
+			wantKeep:  map[string]bool{"dev-workflow@claude-skills": true},
+		},
+		{
+			name: "fully configured is a no-op",
+			settings: map[string]any{
+				"extraKnownMarketplaces": map[string]any{
+					"claude-skills": map[string]any{"source": map[string]any{}},
+				},
+				"enabledPlugins": map[string]any{
+					"dev-workflow@claude-skills": true,
+				},
+			},
+			wantAdded: 0,
+			wantKeep:  map[string]bool{"dev-workflow@claude-skills": true},
+		},
+		{
+			name: "does not overwrite a user-disabled plugin",
+			settings: map[string]any{
+				"enabledPlugins": map[string]any{
+					"dev-workflow@claude-skills": false,
+				},
+			},
+			wantAdded: 1, // only the marketplace is added
+			wantKeep:  map[string]bool{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			added := mergePluginSettings(tt.settings, template())
+
+			if added != tt.wantAdded {
+				t.Errorf("added = %d, want %d", added, tt.wantAdded)
+			}
+
+			enabled, _ := tt.settings["enabledPlugins"].(map[string]any)
+			for plugin, want := range tt.wantKeep {
+				if got, _ := enabled[plugin].(bool); got != want {
+					t.Errorf("enabledPlugins[%q] = %v, want %v", plugin, enabled[plugin], want)
+				}
+			}
+
+			// The user override case must be left untouched.
+			if tt.name == "does not overwrite a user-disabled plugin" {
+				if got := enabled["dev-workflow@claude-skills"]; got != false {
+					t.Errorf("user-disabled plugin was overwritten: got %v", got)
+				}
+			}
+
+			// The marketplace must always be registered afterwards.
+			markets, _ := tt.settings["extraKnownMarketplaces"].(map[string]any)
+			if _, ok := markets["claude-skills"]; !ok {
+				t.Errorf("claude-skills marketplace missing after merge")
+			}
+		})
+	}
+}
+
+func TestMergePluginSettingsIsIdempotent(t *testing.T) {
+	settings := map[string]any{}
+
+	first := mergePluginSettings(settings, template())
+	snapshot := deepCopy(settings)
+
+	second := mergePluginSettings(settings, template())
+
+	if first == 0 {
+		t.Fatalf("first merge added nothing")
+	}
+	if second != 0 {
+		t.Errorf("second merge added %d entries, want 0", second)
+	}
+	if !reflect.DeepEqual(settings, snapshot) {
+		t.Errorf("settings changed on the second merge:\n got %#v\nwant %#v", settings, snapshot)
+	}
+}
+
+func deepCopy(m map[string]any) map[string]any {
+	out := map[string]any{}
+	for k, v := range m {
+		if nested, ok := v.(map[string]any); ok {
+			out[k] = deepCopy(nested)
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}

--- a/nixpkgs/modac-dev-machine/scripts/templates/claude-plugins.json
+++ b/nixpkgs/modac-dev-machine/scripts/templates/claude-plugins.json
@@ -1,0 +1,14 @@
+{
+  "extraKnownMarketplaces": {
+    "claude-skills": {
+      "source": {
+        "source": "github",
+        "repo": "modell-aachen/claude-skills"
+      },
+      "autoUpdate": true
+    }
+  },
+  "enabledPlugins": {
+    "dev-workflow@claude-skills": true
+  }
+}


### PR DESCRIPTION
## What

The `claude` provisioning module now registers the `modell-aachen/claude-skills` plugin marketplace and enables the `dev-workflow` plugin (which ships `/ship-pr`) in `~/.claude/settings.json`.

## Why

The org plugin marketplace was never actually provisioned — the `claude` module only set up `CLAUDE.md` and MCP servers. Any marketplace entry on existing machines was added by hand, so fresh machines got nothing and `/ship-pr` only existed as a project-local skill in QwikiContrib. This makes the marketplace + `dev-workflow` provisioned consistently across machines.

Claude Code auto-installs marketplaces/plugins declared in `settings.json` on startup, so no `/plugin` commands are needed.

## How

- New template `scripts/templates/claude-plugins.json` with `extraKnownMarketplaces` (claude-skills, `autoUpdate: true`) and `enabledPlugins` (`dev-workflow@claude-skills`).
- New `setupPlugins` step in the `claude` module that merges the template into `~/.claude/settings.json`, mirroring the existing MCP-merge pattern.
- Merge is non-destructive: existing marketplaces, enabled plugins, and user overrides (e.g. a deliberately disabled plugin) are preserved. Re-provisioning is idempotent.
- Only `dev-workflow` is auto-enabled; role-specific plugins (obsidian, infrastructure-operations, figma-helper) stay opt-in via `/plugin install`.

## Tests

- Added `claude_test.go` (the package's first tests): table-driven coverage of `mergePluginSettings` — empty settings, preserving unrelated plugins, partial config, no-op when fully configured, not overwriting a user-disabled plugin, plus an idempotency test.
- `go build ./...`, `go vet ./...`, `go test ./...` all pass.

> Note: after merge, the devbox plugin rev hash needs bumping (`machine update-machine-hash`) for machines to pick up the new binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)