### PR TITLE
Resolve host home for distrobox DOCKER_CONFIG

### DIFF
--- a/nixpkgs/modac-dev-machine/internal/provision/dockerpackages/dockerpackages.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/dockerpackages/dockerpackages.go
@@ -118,17 +118,19 @@ func runUbuntu(out *output.Context) error {
 			out.Skipped("Running inside a distrobox, docker already available")
 		}
 
-		// Point DOCKER_CONFIG at the host's .docker directory, independent of
-		// whether docker itself was just linked.
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
 			return fmt.Errorf("failed to get home directory: %w", err)
 		}
 
-		user := os.Getenv("USER")
-		hostDockerDir := fmt.Sprintf("/run/host/home/%s/.docker", user)
+		hostHome, err := hostHomeDir()
+		if err != nil {
+			return fmt.Errorf("failed to determine host home directory: %w", err)
+		}
+
+		dockerConfigDir := filepath.Join(hostHome, ".docker")
 		bashrcPath := filepath.Join(homeDir, ".bashrc")
-		exportLine := fmt.Sprintf("export DOCKER_CONFIG=%q", hostDockerDir)
+		exportLine := fmt.Sprintf("export DOCKER_CONFIG=%q", dockerConfigDir)
 
 		out.Step("Setting DOCKER_CONFIG in .bashrc")
 		if err := appendLineIfMissing(bashrcPath, exportLine); err != nil {
@@ -253,6 +255,19 @@ func appendLineIfMissing(path, line string) error {
 		return err
 	}
 	return nil
+}
+
+func hostHomeDir() (string, error) {
+	out, err := exec.Command("distrobox-host-exec", "printenv", "HOME").Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to query host HOME: %w", err)
+	}
+
+	home := strings.TrimSpace(string(out))
+	if home == "" {
+		return "", fmt.Errorf("host HOME is empty")
+	}
+	return home, nil
 }
 
 func canAccessDockerWithoutSudo() bool {


### PR DESCRIPTION
## What

Fix the `DOCKER_CONFIG` path set for distrobox setups in the `docker-packages` provisioning module so it works across host distros, not only Fedora immutable.

## Why

Inside a distrobox, `docker` is symlinked to `distrobox-host-exec-with-env`, which forwards the container env and runs the real `docker` **on the host**. `DOCKER_CONFIG` is therefore consumed host-side and must be a host path.

The previous value, `/run/host/home/<user>/.docker`, is the *container's* view of the host filesystem and only happened to line up on Fedora immutable hosts; on Ubuntu it does not resolve. The container's own `$HOME` cannot be used either — `distrobox create --home` decouples it from the host, and the host home location varies by distro (`/home/<user>` on Ubuntu vs `/var/home/<user>` on Fedora immutable).

## How

Resolve the host home directory dynamically via `distrobox-host-exec printenv HOME` (bare, non-forwarding, so it reports the host value) and set `DOCKER_CONFIG` to `<hostHome>/.docker`. The export line is still written to the container's `~/.bashrc`.

## Tests

- `go build ./...`, `go vet ./...` pass.
- `nix build .#machine -L` builds successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)