### PR TITLE
Add service machine profile

### DIFF
--- a/.claude/skills/update-machine-hash/scripts/update-machine-hash.sh
+++ b/.claude/skills/update-machine-hash/scripts/update-machine-hash.sh
@@ -2,25 +2,32 @@
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
-PLUGIN_JSON="$REPO_ROOT/devbox/plugins/modac/plugin.json"
-
-if [ ! -f "$PLUGIN_JSON" ]; then
-  echo "ERROR: plugin.json not found at $PLUGIN_JSON" >&2
-  exit 1
-fi
+PLUGIN_JSONS=(
+  "$REPO_ROOT/devbox/plugins/modac/plugin.json"
+  "$REPO_ROOT/devbox/plugins/modac-service/plugin.json"
+)
 
 LATEST_HASH="$(git rev-parse HEAD)"
-# Portable across macOS (BSD) and Linux (GNU): avoid grep -oP and sed -i quirks.
-# There are multiple &rev= refs (machine + google-cloud-sdk-gke); bump them all.
-CURRENT_HASH="$(grep -oE 'rev=[a-f0-9]{40}' "$PLUGIN_JSON" | head -1 | cut -d= -f2)"
 
-if [ "$LATEST_HASH" = "$CURRENT_HASH" ]; then
-  echo "Already up to date (${LATEST_HASH:0:7})"
-  exit 0
-fi
+for plugin_json in "${PLUGIN_JSONS[@]}"; do
+  if [ ! -f "$plugin_json" ]; then
+    echo "ERROR: plugin.json not found at $plugin_json" >&2
+    exit 1
+  fi
 
-tmp="$(mktemp)"
-sed "s/rev=${CURRENT_HASH}/rev=${LATEST_HASH}/g" "$PLUGIN_JSON" > "$tmp"
-cat "$tmp" > "$PLUGIN_JSON"
-rm -f "$tmp"
-echo "Updated machine hash: ${CURRENT_HASH:0:7} -> ${LATEST_HASH:0:7}"
+  # Portable across macOS (BSD) and Linux (GNU): avoid grep -oP and sed -i quirks.
+  # There are multiple &rev= refs (machine + google-cloud-sdk-gke); bump them all.
+  # Hashes are read per file since the plugins can drift apart.
+  CURRENT_HASH="$(grep -oE 'rev=[a-f0-9]{40}' "$plugin_json" | head -1 | cut -d= -f2)"
+
+  if [ "$LATEST_HASH" = "$CURRENT_HASH" ]; then
+    echo "Already up to date (${LATEST_HASH:0:7}): $plugin_json"
+    continue
+  fi
+
+  tmp="$(mktemp)"
+  sed "s/rev=${CURRENT_HASH}/rev=${LATEST_HASH}/g" "$plugin_json" > "$tmp"
+  cat "$tmp" > "$plugin_json"
+  rm -f "$tmp"
+  echo "Updated machine hash: ${CURRENT_HASH:0:7} -> ${LATEST_HASH:0:7}: $plugin_json"
+done

--- a/.github/workflows/update-machine-hash.yml
+++ b/.github/workflows/update-machine-hash.yml
@@ -33,7 +33,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email \
             "41898282+github-actions[bot]@users.noreply.github.com"
-          git add devbox/plugins/modac/plugin.json
+          git add devbox/plugins/*/plugin.json
           short="$(git rev-parse --short HEAD)"
           git commit -m "chore: update machine hash to ${short} [skip ci]"
           git push

--- a/README.md
+++ b/README.md
@@ -67,6 +67,46 @@ machine provision
 
 Back to QwikiContrib: [QwikiContrib](https://github.com/modell-aachen/QwikiContrib/)
 
+## Service machine (Windows/WSL)
+
+Service machines get a minimal setup for Kubernetes access instead of the full
+developer environment: a reduced devbox package set (kubectl, helm, krew, k9s,
+gcloud with GKE auth plugin) and only the service-flagged provisioning modules
+(`machine provision list-modules` marks them with `*`). 1Password is installed
+CLI-only, without the desktop app.
+
+### Windows preparation
+
+1) Open an admin PowerShell and run `wsl --install -d Ubuntu`
+1) Reboot and create your UNIX user when Ubuntu starts
+1) Make sure systemd is enabled in `/etc/wsl.conf` (default on current Ubuntu images):
+   ```
+   [boot]
+   systemd=true
+   ```
+   After changing it, run `wsl --shutdown` from Windows and start WSL again.
+
+### Installation
+
+Inside WSL (or on a plain Ubuntu machine — the service profile is not tied to WSL):
+```BASH
+wget -qO- https://raw.githubusercontent.com/modell-aachen/modac-dev-machine-setup/refs/heads/main/install | MACHINE_PROFILE=service bash; source ~/.bashrc
+```
+
+The profile is persisted in `~/.machine/profile`, so later runs of
+`machine provision` select the service module set automatically. To switch an
+existing machine, run `machine provision --profile service` (or `--profile dev`).
+
+### Provision
+
+```BASH
+machine provision
+```
+
+During provisioning you will be asked to add your 1Password account
+(sign-in address, email, secret key, master password) and to complete the
+device-code login for Kubernetes access.
+
 ## Updates
 Update your `$(devbox global path)/devbox.json`:
 ```BASH

--- a/devbox/plugins/modac-service/plugin.json
+++ b/devbox/plugins/modac-service/plugin.json
@@ -8,7 +8,7 @@
     "git": {
       "version": "latest"
     },
-    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=2a8976c1885975e498a54b17d1937c46c519a875#google-cloud-sdk-gke": {},
+    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=e7e29f0230b7c5191ade1d1e874c124095abfe8f#google-cloud-sdk-gke": {},
     "jq": {
       "version": "latest"
     },
@@ -30,7 +30,7 @@
     "uv": {
       "version": "latest"
     },
-    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=2a8976c1885975e498a54b17d1937c46c519a875": {}
+    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=e7e29f0230b7c5191ade1d1e874c124095abfe8f": {}
   },
   "env": {
     "KREW_ROOT": "$HOME/.krew",

--- a/devbox/plugins/modac-service/plugin.json
+++ b/devbox/plugins/modac-service/plugin.json
@@ -8,7 +8,7 @@
     "git": {
       "version": "latest"
     },
-    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=f70427327e934662f244811dbfa78e21c3277186#google-cloud-sdk-gke": {},
+    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=08eb123eb5bad578bdc17df61babeab944900a07#google-cloud-sdk-gke": {},
     "jq": {
       "version": "latest"
     },
@@ -30,7 +30,7 @@
     "uv": {
       "version": "latest"
     },
-    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=f70427327e934662f244811dbfa78e21c3277186": {}
+    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=08eb123eb5bad578bdc17df61babeab944900a07": {}
   },
   "env": {
     "KREW_ROOT": "$HOME/.krew",

--- a/devbox/plugins/modac-service/plugin.json
+++ b/devbox/plugins/modac-service/plugin.json
@@ -8,7 +8,7 @@
     "git": {
       "version": "latest"
     },
-    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=e7e29f0230b7c5191ade1d1e874c124095abfe8f#google-cloud-sdk-gke": {},
+    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=f70427327e934662f244811dbfa78e21c3277186#google-cloud-sdk-gke": {},
     "jq": {
       "version": "latest"
     },
@@ -30,7 +30,7 @@
     "uv": {
       "version": "latest"
     },
-    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=e7e29f0230b7c5191ade1d1e874c124095abfe8f": {}
+    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=f70427327e934662f244811dbfa78e21c3277186": {}
   },
   "env": {
     "KREW_ROOT": "$HOME/.krew",

--- a/devbox/plugins/modac-service/plugin.json
+++ b/devbox/plugins/modac-service/plugin.json
@@ -1,0 +1,47 @@
+{
+  "name": "MODAC Service",
+  "version": "0.0.1",
+  "packages": {
+    "gh": {
+      "version": "latest"
+    },
+    "git": {
+      "version": "latest"
+    },
+    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=5b42f581ff9f44ee8ef3e7a07703a39c3985588f#google-cloud-sdk-gke": {},
+    "jq": {
+      "version": "latest"
+    },
+    "k9s": {
+      "version": "latest"
+    },
+    "krew": {
+      "version": "latest"
+    },
+    "kubectl": {
+      "version": "latest"
+    },
+    "kubernetes-helm": {
+      "version": "latest"
+    },
+    "kubie": {
+      "version": "latest"
+    },
+    "uv": {
+      "version": "latest"
+    },
+    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=5b42f581ff9f44ee8ef3e7a07703a39c3985588f": {}
+  },
+  "env": {
+    "KREW_ROOT": "$HOME/.krew",
+    "PATH": "$HOME/.krew/bin:$HOME/.local/bin:$PATH"
+  },
+  "shell": {
+    "init_hook": [
+      "_DEVBOX_SHELL=bash; [ -n \"$ZSH_VERSION\" ] && _DEVBOX_SHELL=zsh; type complete &>/dev/null && source <(devbox completion $_DEVBOX_SHELL)",
+      "source <(machine aliases)"
+    ],
+    "scripts": {}
+  },
+  "include": []
+}

--- a/devbox/plugins/modac-service/plugin.json
+++ b/devbox/plugins/modac-service/plugin.json
@@ -8,7 +8,7 @@
     "git": {
       "version": "latest"
     },
-    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=08eb123eb5bad578bdc17df61babeab944900a07#google-cloud-sdk-gke": {},
+    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=fa7f3fd87bf39719dace3cc3011a25d3c6c6084f#google-cloud-sdk-gke": {},
     "jq": {
       "version": "latest"
     },
@@ -30,7 +30,7 @@
     "uv": {
       "version": "latest"
     },
-    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=08eb123eb5bad578bdc17df61babeab944900a07": {}
+    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=fa7f3fd87bf39719dace3cc3011a25d3c6c6084f": {}
   },
   "env": {
     "KREW_ROOT": "$HOME/.krew",

--- a/devbox/plugins/modac-service/plugin.json
+++ b/devbox/plugins/modac-service/plugin.json
@@ -8,7 +8,7 @@
     "git": {
       "version": "latest"
     },
-    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=5b42f581ff9f44ee8ef3e7a07703a39c3985588f#google-cloud-sdk-gke": {},
+    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=2a8976c1885975e498a54b17d1937c46c519a875#google-cloud-sdk-gke": {},
     "jq": {
       "version": "latest"
     },
@@ -30,7 +30,7 @@
     "uv": {
       "version": "latest"
     },
-    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=5b42f581ff9f44ee8ef3e7a07703a39c3985588f": {}
+    "github:modell-aachen/modac-dev-machine-setup?dir=nixpkgs/modac-dev-machine&rev=2a8976c1885975e498a54b17d1937c46c519a875": {}
   },
   "env": {
     "KREW_ROOT": "$HOME/.krew",

--- a/install
+++ b/install
@@ -18,6 +18,14 @@ IS_MACOS=false
 [[ "$OS" == Linux* ]] && IS_LINUX=true
 [[ "$OS" == "Darwin" ]] && IS_MACOS=true
 
+# Machine profile selection (dev = full developer machine, service = minimal
+# Kubernetes access machine). Persisted so 'machine provision' picks it up.
+MACHINE_PROFILE="${MACHINE_PROFILE:-dev}"
+if [[ "$MACHINE_PROFILE" != "dev" && "$MACHINE_PROFILE" != "service" ]]; then
+    echo "Invalid MACHINE_PROFILE '$MACHINE_PROFILE' (valid: dev, service)" >&2
+    exit 1
+fi
+
 logfile="$HOME/.cache/modac-dev-provisioner/install.log"
 mkdir -p "$(dirname "$logfile")"
 echo "Installation started at $(date)" > "$logfile"
@@ -25,6 +33,10 @@ echo "Installation started at $(date)" > "$logfile"
 # Helper functions
 function is_distrobox() {
     [ -n "$CONTAINER_ID" ]
+}
+
+function is_wsl() {
+    [ -n "$WSL_DISTRO_NAME" ] || grep -qi microsoft /proc/sys/kernel/osrelease 2>/dev/null
 }
 
 # Output formatting functions
@@ -67,6 +79,18 @@ function execute() {
 function check_prerequisites() {
     section "Checking Prerequisites"
 
+    # The multi-user Nix installer used by devbox requires systemd
+    if is_wsl && [ ! -d /run/systemd/system ]; then
+        error "systemd is not running in this WSL distribution"
+        echo "Enable systemd by adding the following to /etc/wsl.conf:"
+        echo ""
+        echo "  [boot]"
+        echo "  systemd=true"
+        echo ""
+        echo "Then run 'wsl --shutdown' from Windows and start WSL again."
+        exit 1
+    fi
+
     # Check if running inside a distrobox container
     if is_distrobox; then
         info "Detected running inside a container"
@@ -105,17 +129,22 @@ function check_prerequisites() {
     fi
 }
 
-# Minimal devbox configuration - just includes the modac plugin
-devbox_template=$(cat << 'EOF'
+# Minimal devbox configuration - just includes the plugin for the profile
+plugin_dir="devbox/plugins/modac"
+if [[ "$MACHINE_PROFILE" == "service" ]]; then
+    plugin_dir="devbox/plugins/modac-service"
+fi
+
+devbox_template=$(cat << EOF
 {
-    "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.13.6/.schema/devbox.schema.json",
+    "\$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.13.6/.schema/devbox.schema.json",
     "packages": [],
     "shell": {
         "init_hook": [],
         "scripts": {}
     },
     "include": [
-        "github:modell-aachen/modac-dev-machine-setup?dir=devbox/plugins/modac"
+        "github:modell-aachen/modac-dev-machine-setup?dir=$plugin_dir"
     ]
 }
 EOF
@@ -276,9 +305,17 @@ if [ ! -d "$default_devbox_dir" ]; then
 fi
 
 if [ ! -f "$global_devbox" ]; then
-    info "Creating devbox global configuration"
+    info "Creating devbox global configuration ($MACHINE_PROFILE profile)"
     echo "$devbox_template" > "$global_devbox"
     success "Created $global_devbox"
+fi
+
+# Persist the machine profile so 'machine provision' picks it up automatically
+if [[ "$MACHINE_PROFILE" == "service" ]]; then
+    info "Persisting machine profile '$MACHINE_PROFILE'"
+    mkdir -p "$HOME/.machine"
+    echo "$MACHINE_PROFILE" > "$HOME/.machine/profile"
+    success "Created $HOME/.machine/profile"
 fi
 
 execute "Installing machine CLI via devbox ${BOLD}(this might take a while)${RESET}" devbox global update

--- a/install
+++ b/install
@@ -264,11 +264,11 @@ check_prerequisites
 # ============================================================================
 section "Devbox Setup"
 
-# Install system prerequisites
+# Install system prerequisites (minimal Ubuntu images lack some of these)
 if $IS_LINUX; then
-    if ! command -v curl >/dev/null 2>&1; then
+    if ! command -v curl >/dev/null 2>&1 || ! command -v gpg >/dev/null 2>&1; then
         execute "Updating apt package list" sudo apt update
-        execute "Installing curl" sudo apt install -y curl
+        execute "Installing base packages" sudo apt install -y curl gnupg ca-certificates
     fi
 fi
 

--- a/install
+++ b/install
@@ -286,7 +286,8 @@ if ! command -v devbox >/dev/null 2>&1; then
     if is_distrobox && command -v nix >/dev/null 2>&1; then
         execute "Installing devbox via nix-env" nix-env -iA nixpkgs.devbox
     else
-        execute "Installing Devbox" bash -c "curl -fsSL https://get.jetify.com/devbox | bash"
+        # -f skips the installer's hidden /dev/tty confirmation prompt
+        execute "Installing Devbox" bash -c "curl -fsSL https://get.jetify.com/devbox | bash -s -- -f"
     fi
 fi
 

--- a/install
+++ b/install
@@ -225,12 +225,17 @@ function show_next_steps() {
 
 echo -e "${BOLD}${CYAN}"
 echo "╔════════════════════════════════════════╗"
-echo "║   MODAC Development Bootstrap          ║"
+banner_title="MODAC Development Bootstrap"
+if [[ "$MACHINE_PROFILE" == "service" ]]; then
+    banner_title="MODAC Service Bootstrap"
+fi
+printf "║   %-37s║\n" "$banner_title"
 echo "╚════════════════════════════════════════╝"
 echo -e "${RESET}"
 echo -e "${DIM}This installer bootstraps the minimum required to run 'machine provision':"
 echo -e "  • Devbox - Development environment manager"
-echo -e "  • Machine CLI - Provisioning tool${RESET}\n"
+echo -e "  • Machine CLI - Provisioning tool"
+echo -e "  • Profile: $MACHINE_PROFILE${RESET}\n"
 
 # Confirmation prompt (allow NONINTERACTIVE=1 to skip)
 if [[ "${NONINTERACTIVE}" == "1" ]]; then

--- a/nixpkgs/modac-dev-machine/cmd/machine/provision.go
+++ b/nixpkgs/modac-dev-machine/cmd/machine/provision.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/modell-aachen/machine/internal/config"
 	"github.com/modell-aachen/machine/internal/provision"
 )
 
@@ -19,12 +20,40 @@ var provisionCmd = &cobra.Command{
 			return fmt.Errorf("failed to get filter flag: %w", err)
 		}
 
+		profileFlag, err := cmd.Flags().GetString("profile")
+		if err != nil {
+			return fmt.Errorf("failed to get profile flag: %w", err)
+		}
+
+		profile, err := resolveProfile(profileFlag)
+		if err != nil {
+			return err
+		}
+
 		opts := &provision.Options{
-			Filter: filter,
+			Filter:  filter,
+			Profile: profile,
 		}
 
 		return provision.Execute(opts)
 	},
+}
+
+// resolveProfile persists an explicitly requested profile so later runs pick
+// it up without the flag; otherwise the persisted profile is used.
+func resolveProfile(flagValue string) (config.Profile, error) {
+	if flagValue == "" {
+		return config.LoadProfile()
+	}
+
+	profile, err := config.ParseProfile(flagValue)
+	if err != nil {
+		return "", err
+	}
+	if err := config.SaveProfile(profile); err != nil {
+		return "", err
+	}
+	return profile, nil
 }
 
 var listModulesCmd = &cobra.Command{
@@ -37,12 +66,18 @@ var listModulesCmd = &cobra.Command{
 
 func init() {
 	provisionCmd.Flags().StringP("filter", "f", "", "Comma-separated list of modules to run (tab-completable)")
+	provisionCmd.Flags().String("profile", "", "Machine profile: dev or service (persisted for future runs)")
 	provisionCmd.AddCommand(listModulesCmd)
 
-	provisionCmd.Long += "\n\nUse --filter to run only specific modules (comma-separated). Available modules:\n  " +
+	provisionCmd.Long += "\n\nUse --profile to select the machine profile (dev or service). The choice is" +
+		"\npersisted in ~/.machine/profile and reused when the flag is omitted." +
+		"\n\nUse --filter to run only specific modules (comma-separated). Available modules:\n  " +
 		strings.Join(provision.GetAllModuleNames(), "\n  ")
 
 	_ = provisionCmd.RegisterFlagCompletionFunc("filter", completeFilter)
+	_ = provisionCmd.RegisterFlagCompletionFunc("profile", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{string(config.ProfileDev), string(config.ProfileService)}, cobra.ShellCompDirectiveNoFileComp
+	})
 }
 
 func completeFilter(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/nixpkgs/modac-dev-machine/internal/config/profile.go
+++ b/nixpkgs/modac-dev-machine/internal/config/profile.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type Profile string
+
+const (
+	ProfileDev     Profile = "dev"
+	ProfileService Profile = "service"
+)
+
+func ParseProfile(s string) (Profile, error) {
+	switch Profile(s) {
+	case ProfileDev, ProfileService:
+		return Profile(s), nil
+	default:
+		return "", fmt.Errorf("unknown profile %q (valid: %s, %s)", s, ProfileDev, ProfileService)
+	}
+}
+
+func ProfilePath() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+	return filepath.Join(homeDir, ".machine", "profile"), nil
+}
+
+// LoadProfile reads the persisted machine profile. A missing file means the
+// machine was provisioned before profiles existed, so it defaults to dev.
+func LoadProfile() (Profile, error) {
+	path, err := ProfilePath()
+	if err != nil {
+		return "", err
+	}
+
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return ProfileDev, nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("failed to read profile file: %w", err)
+	}
+
+	profile, err := ParseProfile(strings.TrimSpace(string(data)))
+	if err != nil {
+		return "", fmt.Errorf("invalid profile in %s: %w", path, err)
+	}
+	return profile, nil
+}
+
+func SaveProfile(profile Profile) error {
+	path, err := ProfilePath()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("failed to create profile directory: %w", err)
+	}
+
+	if err := os.WriteFile(path, []byte(profile+"\n"), 0o644); err != nil {
+		return fmt.Errorf("failed to write profile file: %w", err)
+	}
+	return nil
+}

--- a/nixpkgs/modac-dev-machine/internal/config/profile_test.go
+++ b/nixpkgs/modac-dev-machine/internal/config/profile_test.go
@@ -1,0 +1,111 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadProfileDefaultsToDevWhenFileMissing(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	profile, err := LoadProfile()
+	if err != nil {
+		t.Fatalf("LoadProfile() error = %v", err)
+	}
+	if profile != ProfileDev {
+		t.Errorf("LoadProfile() = %q, want %q", profile, ProfileDev)
+	}
+}
+
+func TestSaveProfileRoundTrip(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile Profile
+	}{
+		{"dev profile", ProfileDev},
+		{"service profile", ProfileService},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+
+			if err := SaveProfile(tt.profile); err != nil {
+				t.Fatalf("SaveProfile(%q) error = %v", tt.profile, err)
+			}
+
+			got, err := LoadProfile()
+			if err != nil {
+				t.Fatalf("LoadProfile() error = %v", err)
+			}
+			if got != tt.profile {
+				t.Errorf("LoadProfile() = %q, want %q", got, tt.profile)
+			}
+		})
+	}
+}
+
+func TestLoadProfileTrimsWhitespace(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir := filepath.Join(home, ".machine")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "profile"), []byte("service\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := LoadProfile()
+	if err != nil {
+		t.Fatalf("LoadProfile() error = %v", err)
+	}
+	if got != ProfileService {
+		t.Errorf("LoadProfile() = %q, want %q", got, ProfileService)
+	}
+}
+
+func TestLoadProfileRejectsUnknownContent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dir := filepath.Join(home, ".machine")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "profile"), []byte("laptop"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := LoadProfile(); err == nil {
+		t.Error("LoadProfile() expected error for unknown profile content, got nil")
+	}
+}
+
+func TestParseProfile(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    Profile
+		wantErr bool
+	}{
+		{"dev", "dev", ProfileDev, false},
+		{"service", "service", ProfileService, false},
+		{"unknown value", "laptop", "", true},
+		{"empty string", "", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseProfile(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseProfile(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("ParseProfile(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/nixpkgs/modac-dev-machine/internal/platform/detect.go
+++ b/nixpkgs/modac-dev-machine/internal/platform/detect.go
@@ -29,6 +29,17 @@ func Detect() (Platform, error) {
 	}
 }
 
+// IsWSL reports whether we are running inside Windows Subsystem for Linux.
+// WSL machines are treated as Ubuntu; modules use this to skip desktop-only steps.
+func IsWSL() bool {
+	kernelRelease, _ := os.ReadFile("/proc/sys/kernel/osrelease")
+	return isWSL(os.Getenv("WSL_DISTRO_NAME"), string(kernelRelease))
+}
+
+func isWSL(distroName, kernelRelease string) bool {
+	return distroName != "" || strings.Contains(strings.ToLower(kernelRelease), "microsoft")
+}
+
 func detectLinuxDistro() (Platform, error) {
 	// Check /etc/os-release for distribution info
 	data, err := os.ReadFile("/etc/os-release")

--- a/nixpkgs/modac-dev-machine/internal/platform/detect_test.go
+++ b/nixpkgs/modac-dev-machine/internal/platform/detect_test.go
@@ -1,0 +1,27 @@
+package platform
+
+import "testing"
+
+func TestIsWSL(t *testing.T) {
+	tests := []struct {
+		name          string
+		distroName    string
+		kernelRelease string
+		want          bool
+	}{
+		{"WSL_DISTRO_NAME set", "Ubuntu", "", true},
+		{"microsoft kernel (WSL2)", "", "5.15.167.4-microsoft-standard-WSL2", true},
+		{"microsoft kernel uppercase (WSL1)", "", "4.4.0-19041-Microsoft", true},
+		{"both signals", "Ubuntu", "5.15.167.4-microsoft-standard-WSL2", true},
+		{"plain Ubuntu kernel", "", "6.8.0-45-generic", false},
+		{"no signals", "", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isWSL(tt.distroName, tt.kernelRelease); got != tt.want {
+				t.Errorf("isWSL(%q, %q) = %v, want %v", tt.distroName, tt.kernelRelease, got, tt.want)
+			}
+		})
+	}
+}

--- a/nixpkgs/modac-dev-machine/internal/provision/executor.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/executor.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/modell-aachen/machine/internal/config"
 	"github.com/modell-aachen/machine/internal/output"
 	"github.com/modell-aachen/machine/internal/platform"
 	"github.com/modell-aachen/machine/internal/provision/asdf"
@@ -35,39 +36,41 @@ import (
 )
 
 type Options struct {
-	Filter string
+	Filter  string
+	Profile config.Profile
 }
 
 type ModuleEntry struct {
-	Name   string
-	Runner func(*output.Context, platform.Platform) error
+	Name    string
+	Runner  func(*output.Context, platform.Platform) error
+	Service bool // part of the minimal service machine profile
 }
 
 const devboxUpdateModuleName = "devbox-update"
 
 var allModules = []ModuleEntry{
-	{"nix-conf", nixconf.Run},
-	{devboxUpdateModuleName, devboxupdate.Run},
-	{"onepassword", onepassword.Run},
-	{"restore-backup", restorebackup.Run},
-	{"packages", packages.Run},
-	{"setup-envs", setupenvs.Run},
-	{"asdf-packages", asdfpackages.Run},
-	{"asdf", asdf.Run},
-	{"kubectl-krew", kubectlkrew.Run},
-	{"setup-k8s-cluster", setupk8scluster.Run},
-	{"node", node.Run},
-	{"nssdb", nssdb.Run},
-	{"certificates", certificates.Run},
-	{"setup-dev", setupdev.Run},
-	{"completions", completions.Run},
-	{"claude", claude.Run},
-	{"github-auth-login", githubauthlogin.Run},
-	{"gcloud-workforce-login", gcloudworkforcelogin.Run},
-	{"install-modac-shell-helper", installmodacshellhelper.Run},
-	{"orbstack", orbstack.Run},
-	{"docker-packages", dockerpackages.Run},
-	{"docker", docker.Run},
+	{Name: "nix-conf", Runner: nixconf.Run, Service: true},
+	{Name: devboxUpdateModuleName, Runner: devboxupdate.Run, Service: true},
+	{Name: "onepassword", Runner: onepassword.Run, Service: true},
+	{Name: "restore-backup", Runner: restorebackup.Run},
+	{Name: "packages", Runner: packages.Run},
+	{Name: "setup-envs", Runner: setupenvs.Run},
+	{Name: "asdf-packages", Runner: asdfpackages.Run},
+	{Name: "asdf", Runner: asdf.Run},
+	{Name: "kubectl-krew", Runner: kubectlkrew.Run, Service: true},
+	{Name: "setup-k8s-cluster", Runner: setupk8scluster.Run, Service: true},
+	{Name: "node", Runner: node.Run},
+	{Name: "nssdb", Runner: nssdb.Run},
+	{Name: "certificates", Runner: certificates.Run},
+	{Name: "setup-dev", Runner: setupdev.Run},
+	{Name: "completions", Runner: completions.Run},
+	{Name: "claude", Runner: claude.Run},
+	{Name: "github-auth-login", Runner: githubauthlogin.Run, Service: true},
+	{Name: "gcloud-workforce-login", Runner: gcloudworkforcelogin.Run, Service: true},
+	{Name: "install-modac-shell-helper", Runner: installmodacshellhelper.Run, Service: true},
+	{Name: "orbstack", Runner: orbstack.Run},
+	{Name: "docker-packages", Runner: dockerpackages.Run},
+	{Name: "docker", Runner: docker.Run},
 }
 
 func GetAllModuleNames() []string {
@@ -78,24 +81,27 @@ func GetAllModuleNames() []string {
 	return names
 }
 
-func FilterModules(filter string) []ModuleEntry {
-	if filter == "" {
-		return allModules
-	}
-
+// ModulesFor returns the modules for a profile, optionally narrowed by a
+// comma-separated filter. Definition order is always preserved; filter names
+// outside the profile are dropped silently.
+func ModulesFor(profile config.Profile, filter string) []ModuleEntry {
 	filterMap := make(map[string]bool)
 	for _, name := range splitCSV(filter) {
 		filterMap[name] = true
 	}
 
-	filtered := []ModuleEntry{}
+	modules := []ModuleEntry{}
 	for _, module := range allModules {
-		if filterMap[module.Name] {
-			filtered = append(filtered, module)
+		if profile == config.ProfileService && !module.Service {
+			continue
 		}
+		if filter != "" && !filterMap[module.Name] {
+			continue
+		}
+		modules = append(modules, module)
 	}
 
-	return filtered
+	return modules
 }
 
 func Execute(opts *Options) error {
@@ -105,7 +111,7 @@ func Execute(opts *Options) error {
 	}
 	defer out.Close()
 
-	fmt.Printf("Machine Provisioning\n")
+	fmt.Printf("Machine Provisioning (%s profile)\n", opts.Profile)
 	fmt.Printf("Log file: %s\n\n", out.LogPath())
 
 	plat, err := platform.Detect()
@@ -113,7 +119,7 @@ func Execute(opts *Options) error {
 		return fmt.Errorf("platform detection failed: %w", err)
 	}
 
-	modules := FilterModules(opts.Filter)
+	modules := ModulesFor(opts.Profile, opts.Filter)
 
 	self := currentBinary()
 
@@ -178,9 +184,13 @@ func reexecAfterUpdate(out *output.Context, self string) error {
 }
 
 func ListModules() error {
-	fmt.Println("Available modules:")
-	for _, module := range GetAllModuleNames() {
-		fmt.Printf("  - %s\n", module)
+	fmt.Println("Available modules (* = included in service profile):")
+	for _, module := range allModules {
+		marker := ""
+		if module.Service {
+			marker = " *"
+		}
+		fmt.Printf("  - %s%s\n", module.Name, marker)
 	}
 	return nil
 }

--- a/nixpkgs/modac-dev-machine/internal/provision/executor_test.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/executor_test.go
@@ -1,6 +1,124 @@
 package provision
 
-import "testing"
+import (
+	"slices"
+	"testing"
+
+	"github.com/modell-aachen/machine/internal/config"
+)
+
+func moduleNames(modules []ModuleEntry) []string {
+	names := make([]string, len(modules))
+	for i, module := range modules {
+		names[i] = module.Name
+	}
+	return names
+}
+
+func TestModulesFor(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile config.Profile
+		filter  string
+		want    []string
+	}{
+		{
+			name:    "dev without filter returns all modules",
+			profile: config.ProfileDev,
+			filter:  "",
+			want:    GetAllModuleNames(),
+		},
+		{
+			name:    "dev with filter keeps definition order",
+			profile: config.ProfileDev,
+			filter:  "packages,nix-conf",
+			want:    []string{"nix-conf", "packages"},
+		},
+		{
+			name:    "dev with unknown names drops them silently",
+			profile: config.ProfileDev,
+			filter:  "nix-conf,does-not-exist",
+			want:    []string{"nix-conf"},
+		},
+		{
+			name:    "service without filter returns service modules in order",
+			profile: config.ProfileService,
+			filter:  "",
+			want: []string{
+				"nix-conf",
+				"devbox-update",
+				"onepassword",
+				"kubectl-krew",
+				"setup-k8s-cluster",
+				"github-auth-login",
+				"gcloud-workforce-login",
+				"install-modac-shell-helper",
+			},
+		},
+		{
+			name:    "service with filter intersects with service set",
+			profile: config.ProfileService,
+			filter:  "kubectl-krew,orbstack,claude",
+			want:    []string{"kubectl-krew"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := moduleNames(ModulesFor(tt.profile, tt.filter))
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("ModulesFor(%q, %q) = %v, want %v", tt.profile, tt.filter, got, tt.want)
+			}
+		})
+	}
+}
+
+// modulePrereqs documents the implicit dependencies encoded in allModules
+// ordering. Every profile must contain each prerequisite of its modules,
+// and the prerequisite must run first.
+var modulePrereqs = []struct{ module, requires string }{
+	{"devbox-update", "nix-conf"},
+	{"restore-backup", "onepassword"},
+	{"setup-envs", "onepassword"},
+	{"kubectl-krew", "devbox-update"},
+	{"setup-k8s-cluster", "onepassword"},
+	{"setup-k8s-cluster", "devbox-update"},
+	{"certificates", "nssdb"},
+	{"install-modac-shell-helper", "github-auth-login"},
+	{"install-modac-shell-helper", "devbox-update"},
+}
+
+func TestProfilesAreDependencyClosed(t *testing.T) {
+	for _, profile := range []config.Profile{config.ProfileDev, config.ProfileService} {
+		names := moduleNames(ModulesFor(profile, ""))
+		for _, prereq := range modulePrereqs {
+			moduleIdx := slices.Index(names, prereq.module)
+			if moduleIdx == -1 {
+				continue
+			}
+			requiresIdx := slices.Index(names, prereq.requires)
+			if requiresIdx == -1 {
+				t.Errorf("profile %q contains %q but not its prerequisite %q", profile, prereq.module, prereq.requires)
+				continue
+			}
+			if requiresIdx > moduleIdx {
+				t.Errorf("profile %q runs %q before its prerequisite %q", profile, prereq.module, prereq.requires)
+			}
+		}
+	}
+}
+
+func TestPrereqTableReferencesExistingModules(t *testing.T) {
+	names := GetAllModuleNames()
+	for _, prereq := range modulePrereqs {
+		if !slices.Contains(names, prereq.module) {
+			t.Errorf("modulePrereqs references unknown module %q", prereq.module)
+		}
+		if !slices.Contains(names, prereq.requires) {
+			t.Errorf("modulePrereqs references unknown prerequisite %q", prereq.requires)
+		}
+	}
+}
 
 func TestBinaryChanged(t *testing.T) {
 	tests := []struct {

--- a/nixpkgs/modac-dev-machine/internal/provision/onepassword/onepassword.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/onepassword/onepassword.go
@@ -131,6 +131,17 @@ func isDebPackageInstalled(name string) bool {
 }
 
 func ensureAptRepo(out *output.Context) error {
+	// Minimal Ubuntu images (e.g. fresh WSL) ship without gnupg
+	if _, err := exec.LookPath("gpg"); err != nil {
+		out.Step("Installing gnupg")
+		if err := out.RunCommand("sudo", "apt", "update"); err != nil {
+			return fmt.Errorf("failed to update apt: %w", err)
+		}
+		if err := out.RunCommand("sudo", "apt", "install", "-y", "gnupg"); err != nil {
+			return fmt.Errorf("failed to install gnupg: %w", err)
+		}
+	}
+
 	opKeyring := "/usr/share/keyrings/1password-archive-keyring.gpg"
 	if _, err := os.Stat(opKeyring); os.IsNotExist(err) {
 		out.Step("Adding 1Password GPG keyring")

--- a/nixpkgs/modac-dev-machine/internal/provision/onepassword/onepassword.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/onepassword/onepassword.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/modell-aachen/machine/internal/config"
@@ -142,19 +143,30 @@ func ensureAptRepo(out *output.Context) error {
 		}
 	}
 
-	opKeyring := "/usr/share/keyrings/1password-archive-keyring.gpg"
-	if _, err := os.Stat(opKeyring); os.IsNotExist(err) {
+	if _, err := os.Stat(opKeyringPath); os.IsNotExist(err) {
 		out.Step("Adding 1Password GPG keyring")
-		if err := out.RunCommand("bash", "-c", "curl -sS https://downloads.1password.com/linux/keys/1password.asc | sudo gpg --dearmor --output "+opKeyring); err != nil {
+		if err := out.RunCommand("bash", "-c", "curl -sS https://downloads.1password.com/linux/keys/1password.asc | sudo gpg --dearmor --output "+opKeyringPath); err != nil {
 			return fmt.Errorf("failed to add 1Password keyring: %w", err)
 		}
 	}
 
+	arch, err := debArchitecture()
+	if err != nil {
+		return err
+	}
+
+	// Rewrite when the content differs so a wrong architecture heals itself
 	opSourceList := "/etc/apt/sources.list.d/1password.list"
-	if _, err := os.Stat(opSourceList); os.IsNotExist(err) {
+	sourceLine := aptSourceLine(arch)
+	current, _ := os.ReadFile(opSourceList)
+	if strings.TrimSpace(string(current)) != sourceLine {
 		out.Step("Adding 1Password apt repository")
-		if err := out.RunCommand("bash", "-c", fmt.Sprintf("echo 'deb [arch=amd64 signed-by=%s] https://downloads.1password.com/linux/debian/amd64 stable main' | sudo tee %s", opKeyring, opSourceList)); err != nil {
+		if err := out.RunCommand("bash", "-c", fmt.Sprintf("echo '%s' | sudo tee %s", sourceLine, opSourceList)); err != nil {
 			return fmt.Errorf("failed to add 1Password repository: %w", err)
+		}
+		out.Step("Updating apt package list")
+		if err := out.RunCommand("sudo", "apt", "update"); err != nil {
+			return fmt.Errorf("failed to update apt: %w", err)
 		}
 	}
 
@@ -187,6 +199,20 @@ func ensureAptRepo(out *output.Context) error {
 	}
 
 	return nil
+}
+
+const opKeyringPath = "/usr/share/keyrings/1password-archive-keyring.gpg"
+
+func aptSourceLine(arch string) string {
+	return fmt.Sprintf("deb [arch=%s signed-by=%s] https://downloads.1password.com/linux/debian/%s stable main", arch, opKeyringPath, arch)
+}
+
+func debArchitecture() (string, error) {
+	output, err := exec.Command("dpkg", "--print-architecture").Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to determine dpkg architecture: %w", err)
+	}
+	return strings.TrimSpace(string(output)), nil
 }
 
 func isDistrobox() bool {

--- a/nixpkgs/modac-dev-machine/internal/provision/onepassword/onepassword.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/onepassword/onepassword.go
@@ -2,12 +2,15 @@ package onepassword
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"time"
 
+	"github.com/modell-aachen/machine/internal/config"
 	"github.com/modell-aachen/machine/internal/output"
 	"github.com/modell-aachen/machine/internal/platform"
 )
@@ -41,20 +44,93 @@ func runDarwin(out *output.Context) error {
 }
 
 func runUbuntu(out *output.Context) error {
+	cliOnly, err := useCLIOnly()
+	if err != nil {
+		return err
+	}
+	if cliOnly {
+		return runUbuntuCLIOnly(out)
+	}
+
 	// Check if 1password is already installed
-	cmd := exec.Command("dpkg", "-l", "1password")
-	output, _ := cmd.CombinedOutput()
-	if cmd.ProcessState.ExitCode() == 0 && len(output) > 0 {
-		// Check if package is actually installed (starts with 'ii')
-		if len(output) > 2 && output[0] == 'i' && output[1] == 'i' {
-			out.Skipped("1Password already installed")
-			if err := exportToDistroboxIfNeeded(out); err != nil {
-				return err
-			}
-			return postInstallSetup(out, platform.Ubuntu)
+	if isDebPackageInstalled("1password") {
+		out.Skipped("1Password already installed")
+		if err := exportToDistroboxIfNeeded(out); err != nil {
+			return err
+		}
+		return postInstallSetup(out, platform.Ubuntu)
+	}
+
+	if err := ensureAptRepo(out); err != nil {
+		return err
+	}
+
+	out.Step("Installing 1Password and CLI")
+	if err := out.RunCommand("sudo", "apt", "install", "-y", "1password", "1password-cli"); err != nil {
+		return fmt.Errorf("failed to install 1Password: %w", err)
+	}
+
+	if isDistrobox() {
+		out.Step("Installing audio libraries for Distrobox")
+		if err := out.RunCommand("sudo", "apt", "install", "-y", "libasound2t64"); err != nil {
+			return fmt.Errorf("failed to install audio libraries: %w", err)
 		}
 	}
 
+	if err := exportToDistroboxIfNeeded(out); err != nil {
+		return err
+	}
+
+	return postInstallSetup(out, platform.Ubuntu)
+}
+
+// useCLIOnly decides whether to skip the desktop app entirely: service
+// machines never need it, and under WSL there is no desktop to run it on.
+func useCLIOnly() (bool, error) {
+	if platform.IsWSL() {
+		return true, nil
+	}
+	profile, err := config.LoadProfile()
+	if err != nil {
+		return false, err
+	}
+	return profile == config.ProfileService, nil
+}
+
+func runUbuntuCLIOnly(out *output.Context) error {
+	if isDebPackageInstalled("1password-cli") {
+		out.Skipped("1Password CLI already installed")
+		return postInstallSetupCLIOnly(out)
+	}
+
+	if err := ensureAptRepo(out); err != nil {
+		return err
+	}
+
+	out.Step("Updating apt package list")
+	if err := out.RunCommand("sudo", "apt", "update"); err != nil {
+		return fmt.Errorf("failed to update apt: %w", err)
+	}
+
+	out.Step("Installing 1Password CLI")
+	if err := out.RunCommand("sudo", "apt", "install", "-y", "1password-cli"); err != nil {
+		return fmt.Errorf("failed to install 1Password CLI: %w", err)
+	}
+
+	return postInstallSetupCLIOnly(out)
+}
+
+func isDebPackageInstalled(name string) bool {
+	cmd := exec.Command("dpkg", "-l", name)
+	output, _ := cmd.CombinedOutput()
+	if cmd.ProcessState.ExitCode() != 0 {
+		return false
+	}
+	// Package is actually installed when the status line starts with 'ii'
+	return len(output) > 2 && output[0] == 'i' && output[1] == 'i'
+}
+
+func ensureAptRepo(out *output.Context) error {
 	opKeyring := "/usr/share/keyrings/1password-archive-keyring.gpg"
 	if _, err := os.Stat(opKeyring); os.IsNotExist(err) {
 		out.Step("Adding 1Password GPG keyring")
@@ -99,23 +175,7 @@ func runUbuntu(out *output.Context) error {
 		}
 	}
 
-	out.Step("Installing 1Password and CLI")
-	if err := out.RunCommand("sudo", "apt", "install", "-y", "1password", "1password-cli"); err != nil {
-		return fmt.Errorf("failed to install 1Password: %w", err)
-	}
-
-	if isDistrobox() {
-		out.Step("Installing audio libraries for Distrobox")
-		if err := out.RunCommand("sudo", "apt", "install", "-y", "libasound2t64"); err != nil {
-			return fmt.Errorf("failed to install audio libraries: %w", err)
-		}
-	}
-
-	if err := exportToDistroboxIfNeeded(out); err != nil {
-		return err
-	}
-
-	return postInstallSetup(out, platform.Ubuntu)
+	return nil
 }
 
 func isDistrobox() bool {
@@ -226,6 +286,61 @@ func ensureCLIIntegration(out *output.Context) error {
 			return fmt.Errorf("failed to read user input: %w", err)
 		}
 	}
+}
+
+// postInstallSetupCLIOnly signs in without the desktop app. The session token
+// is exported into this process so later modules (setup-k8s-cluster) can use
+// op within the same provision run. A 1Password service account via
+// OP_SERVICE_ACCOUNT_TOKEN would be the non-interactive alternative.
+func postInstallSetupCLIOnly(out *output.Context) error {
+	if !hasConfiguredAccount() {
+		out.Step("Adding 1Password account")
+		cmd := exec.Command("op", "account", "add")
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("failed to add 1Password account: %w", err)
+		}
+	}
+
+	out.Step("Signing in to 1Password CLI")
+	var stdout bytes.Buffer
+	cmd := exec.Command("op", "signin")
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = &stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to sign in to 1Password CLI: %w", err)
+	}
+
+	for name, token := range parseSessionExports(stdout.String()) {
+		if err := os.Setenv(name, token); err != nil {
+			return fmt.Errorf("failed to export 1Password session: %w", err)
+		}
+	}
+
+	out.Success("Signed in to 1Password CLI")
+	return nil
+}
+
+func hasConfiguredAccount() bool {
+	output, err := exec.Command("op", "--format", "json", "account", "list").Output()
+	if err != nil {
+		return false
+	}
+	var accounts []interface{}
+	return json.Unmarshal(output, &accounts) == nil && len(accounts) > 0
+}
+
+var sessionExportPattern = regexp.MustCompile(`(?m)^export (OP_SESSION_[A-Za-z0-9_]+)="([^"]+)"$`)
+
+func parseSessionExports(signinOutput string) map[string]string {
+	sessions := map[string]string{}
+	for _, match := range sessionExportPattern.FindAllStringSubmatch(signinOutput, -1) {
+		sessions[match[1]] = match[2]
+	}
+	return sessions
 }
 
 func signInUser(out *output.Context) error {

--- a/nixpkgs/modac-dev-machine/internal/provision/onepassword/onepassword_test.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/onepassword/onepassword_test.go
@@ -1,0 +1,50 @@
+package onepassword
+
+import (
+	"maps"
+	"testing"
+)
+
+func TestParseSessionExports(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   map[string]string
+	}{
+		{
+			name:   "single export line",
+			output: `export OP_SESSION_my="abc123"` + "\n",
+			want:   map[string]string{"OP_SESSION_my": "abc123"},
+		},
+		{
+			name: "export line with trailing comment output",
+			output: `export OP_SESSION_modellaachen="tok-en_value"` + "\n" +
+				`# This command is meant to be used with your shell's eval function.` + "\n",
+			want: map[string]string{"OP_SESSION_modellaachen": "tok-en_value"},
+		},
+		{
+			name:   "no export lines",
+			output: "some unrelated output\n",
+			want:   map[string]string{},
+		},
+		{
+			name:   "empty output",
+			output: "",
+			want:   map[string]string{},
+		},
+		{
+			name:   "ignores non-session exports",
+			output: `export PATH="/usr/bin"` + "\n" + `export OP_SESSION_x="y"` + "\n",
+			want:   map[string]string{"OP_SESSION_x": "y"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseSessionExports(tt.output)
+			if !maps.Equal(got, tt.want) {
+				t.Errorf("parseSessionExports(%q) = %v, want %v", tt.output, got, tt.want)
+			}
+		})
+	}
+}

--- a/nixpkgs/modac-dev-machine/internal/provision/onepassword/onepassword_test.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/onepassword/onepassword_test.go
@@ -5,6 +5,33 @@ import (
 	"testing"
 )
 
+func TestAptSourceLine(t *testing.T) {
+	tests := []struct {
+		name string
+		arch string
+		want string
+	}{
+		{
+			name: "amd64",
+			arch: "amd64",
+			want: "deb [arch=amd64 signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/amd64 stable main",
+		},
+		{
+			name: "arm64",
+			arch: "arm64",
+			want: "deb [arch=arm64 signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/arm64 stable main",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := aptSourceLine(tt.arch); got != tt.want {
+				t.Errorf("aptSourceLine(%q) = %q, want %q", tt.arch, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseSessionExports(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/nixpkgs/modac-dev-machine/internal/provision/setupk8scluster/setupk8scluster.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/setupk8scluster/setupk8scluster.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"os/exec"
-	"strings"
 
 	"github.com/modell-aachen/machine/internal/output"
 	"github.com/modell-aachen/machine/internal/platform"
@@ -53,18 +52,10 @@ func Run(out *output.Context, plat platform.Platform) error {
 }
 
 func checkOpSignIn() error {
-	cmd := exec.Command("op", "signin")
-	output, err := cmd.CombinedOutput()
-
-	// If the output contains "[ERROR]", user is not signed in
-	if strings.Contains(string(output), "[ERROR]") {
-		return fmt.Errorf("you are not logged in to 1Password CLI. Please log into 1Password CLI and try again")
+	// whoami works with both the desktop app integration and an exported
+	// OP_SESSION token; op signin would prompt for a password without stdin
+	if err := exec.Command("op", "whoami").Run(); err != nil {
+		return fmt.Errorf("you are not logged in to 1Password CLI. Please log in (eval $(op signin)) and try again")
 	}
-
-	// If there's an error and it's not about being signed in, return it
-	if err != nil && !strings.Contains(string(output), "signed in") {
-		return fmt.Errorf("failed to check 1Password CLI sign-in status: %w", err)
-	}
-
 	return nil
 }


### PR DESCRIPTION
## Summary

Adds a second machine profile so that besides developer machines, **service machines** (Windows/WSL, purpose: Kubernetes access) can be provisioned with a minimal subset of modules and packages.

## Changes

**Module flagging**
- `ModuleEntry` gains a `Service` flag; 8 modules form the service set: `nix-conf`, `devbox-update`, `onepassword`, `kubectl-krew`, `setup-k8s-cluster`, `github-auth-login`, `gcloud-workforce-login`, `install-modac-shell-helper`
- New `ModulesFor(profile, filter)` replaces `FilterModules`; `-f` now intersects with the active profile set. Dev profile without a marker file behaves exactly as before (asserted by test)
- `machine provision list-modules` marks service modules with `*`

**Profile selection**
- New `--profile dev|service` flag on `machine provision`, persisted to `~/.machine/profile` and reused on later runs without the flag; missing file defaults to `dev`
- The install script accepts `MACHINE_PROFILE=service`, selects the matching devbox plugin include, writes the profile marker and shows the profile in the bootstrap banner

**WSL support**
- `platform.IsWSL()` detects WSL via `WSL_DISTRO_NAME` / kernel release; the platform stays `Ubuntu`, so all existing module switches keep working
- Install script verifies systemd is enabled in WSL (required by the Nix installer) and prints `/etc/wsl.conf` instructions otherwise
- 1Password: CLI-only path (no desktop app) when the profile is `service` **or** running under WSL — the service profile is therefore fully testable on plain Ubuntu. The `op signin` session is exported into the provision process so `setup-k8s-cluster` works in the same run. `OP_SERVICE_ACCOUNT_TOKEN` is noted in code as the future non-interactive alternative

**Robustness fixes from end-to-end testing on a fresh VM**
- devbox installer runs with `-f`, skipping its hidden `/dev/tty` confirmation prompt that looked like a hang
- Install script preinstalls `curl gnupg ca-certificates` on Linux; the onepassword module additionally self-heals a missing `gpg`
- 1Password apt repo uses `dpkg --print-architecture` instead of hardcoded `amd64` (fresh WSL on ARM devices is arm64; the CLI is available for arm64, the desktop app is not). A wrong existing sources list heals itself via content comparison
- `setup-k8s-cluster` checks the 1Password sign-in via `op whoami` (works with both desktop-app integration and `OP_SESSION` tokens) instead of `op signin` without stdin, which dead-ended in a password prompt on CLI-only machines. `op whoami` is the same check `setup-envs` and `machine backup` already use, so dev machines are unaffected

**Dependency guarantee**
- No dependency graph added; instead a table-driven test encodes the implicit prerequisite edges (e.g. `setup-k8s-cluster` → `onepassword`, `install-modac-shell-helper` → `github-auth-login`) and asserts every profile is dependency-closed and correctly ordered

**New service devbox plugin**
- `devbox/plugins/modac-service/plugin.json` with a minimal package set: machine binary, google-cloud-sdk-gke, kubectl, kubernetes-helm, krew, kubie, k9s, jq, git, gh, uv
- `update-machine-hash` script and workflow now bump the rev hash in both plugin files
- The service plugin currently pins a branch commit for testing; the workflow re-bumps it after merge

**Docs**
- README section "Service machine (Windows/WSL)" with the end-to-end setup flow

## Verification

- `go test ./...`, `go vet ./...` green (new tests: profile persistence, WSL detection, `ModulesFor`, dependency closure, op session parser, apt source line)
- `nix build .#machine` succeeds; built binary smoke-tested
- `machine provision -f nix-conf` exercised in an isolated `$HOME` for both profiles (dev default, service via marker file)
- End-to-end bootstrap + provisioning exercised on a fresh WSL/Ubuntu VM (arm64) up to the 1Password/Kubernetes modules; the robustness fixes above are the results
- Hash-update script verified to bump both plugin files