### PR TITLE
Use getopt and sed from Nix instead of Homebrew in qypress and qinfo commands

### DIFF
--- a/devbox/plugins/modac/plugin.json
+++ b/devbox/plugins/modac/plugin.json
@@ -125,7 +125,7 @@
   },
   "shell": {
     "init_hook": [
-      "[ -n \"$HOMEBREW_PREFIX\" ] && export PATH=\"$HOMEBREW_PREFIX/bin:$HOMEBREW_PREFIX/opt/gnu-getopt/bin:$HOMEBREW_PREFIX/opt/gnu-sed/libexec/gnubin:$PATH\"",
+      "[ -n \"$HOMEBREW_PREFIX\" ] && export PATH=\"$HOMEBREW_PREFIX/bin:$PATH\"",
       "_DEVBOX_SHELL=bash; [ -n \"$ZSH_VERSION\" ] && _DEVBOX_SHELL=zsh; type complete &>/dev/null && source <(devbox completion $_DEVBOX_SHELL)",
       "_DEVBOX_SHELL=bash; [ -n \"$ZSH_VERSION\" ] && _DEVBOX_SHELL=zsh; eval \"$(direnv hook $_DEVBOX_SHELL)\"",
       "source <(machine aliases)",

--- a/nixpkgs/modac-dev-machine/flake.nix
+++ b/nixpkgs/modac-dev-machine/flake.nix
@@ -33,6 +33,8 @@
             # Go module vendoring hash
             vendorHash = "sha256-7K17JaXFsjf163g5PXCb5ng2gYdotnZ2IDKk8KFjNj0=";
 
+            nativeBuildInputs = [ pkgs.makeWrapper ];
+
             # Install templates alongside binary (scripts are now in Go)
             postInstall = ''
               mkdir -p $out/share/machine
@@ -43,6 +45,14 @@
 
               cp -r scripts/bash/* $out/bin
               cp -r scripts/completions/* $out/share/bash-completion/completions
+
+              # qypress and qinfo rely on util-linux's getopt (the enhanced
+              # getopt(1) supporting long options) and qypress also uses GNU
+              # sed, neither of which macOS's built-in BSD tools provide.
+              wrapProgram $out/bin/qypress \
+                --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.util-linux pkgs.gnused ]}
+              wrapProgram $out/bin/qinfo \
+                --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.util-linux ]}
             '';
 
             ldflags = [

--- a/nixpkgs/modac-dev-machine/internal/provision/packages/packages.go
+++ b/nixpkgs/modac-dev-machine/internal/provision/packages/packages.go
@@ -29,14 +29,12 @@ func runDarwin(out *output.Context) error {
 	brewPackages := []string{
 		"bash",
 		"gettext",
-		"gnu-getopt",
 		"gpg",
 		"openssh",
 		"libfido2",
 		"openvpn",
 		"nmap",
 		"fswatch",
-		"gnu-sed",
 	}
 
 	brewCasks := []string{


### PR DESCRIPTION
`HOMEBREW_PREFIX` env variable isn't set on my machine due to the parallel orgavision setup. This causes the `PATH` not to be updated to include the GNU versions of `getopts` and `sed` which the `qypress` command expects.

This change sets `PATH` for `qypress` and `qinfo` commands to point to Nix-provided GNU versions.