### PR TITLE
Fix `/dev/fd/13:43: command not found: complete` error during shell init

### DIFF
--- a/nixpkgs/modac-dev-machine/cmd/machine/aliases.go
+++ b/nixpkgs/modac-dev-machine/cmd/machine/aliases.go
@@ -48,6 +48,10 @@ _qlone-completion()
     COMPREPLY=( $(compgen -W "$repos" -- ${cur}) )
 }
 
+if [ -n "$ZSH_VERSION" ] && (( $+functions[compdef] )); then
+    autoload -Uz bashcompinit && bashcompinit
+fi
+
 complete -F _qlone-completion qlone
 
 alias k='kubectl'


### PR DESCRIPTION
under zsh

We use `complete` in the shell script from `aliases.go` which is a Bash-builtin and by default not available on zsh.
Some colleagues were lucky to have set up `nvm` locally which already enables zsh's compatibility layer for Bash's `complete` command. Withput `nvm` the `command not found` error appeared on every new shell. We initialize zsh's compat layer here to be sure it always works.