### PR TITLE
Nexus pkg-reader npm auth ident in die Provisionierung aufnehmen

### DIFF
--- a/nixpkgs/modac-dev-machine/scripts/templates/devbox.json
+++ b/nixpkgs/modac-dev-machine/scripts/templates/devbox.json
@@ -10,6 +10,7 @@
         "HARBOR_PASSWORD": "op://Employee/Harbor/password",
         "NEXUS_BOT_TOKEN": "op://4kbrfouay733wowrd7fkpkcymq/Nexus - Bot Readonly/password",
         "FONTAWESOME_NEXUS_AUTH_TOKEN": "op://Entwicklung/FONTAWESOME_NEXUS_AUTH_TOKEN/password",
+        "PKG_READER_NEXUS_AUTH_IDENT": "op://Entwicklung/nexus-user-pkg-reader/npm-auth-ident",
         "NPM_MODAC_CLOUD_AUTH_TOKEN": "op://Entwicklung/npm-bot auth token - npm.modac.cloud/password",
         "GRAFANA_SERVICE_ACCOUNT_TOKEN": "op://Entwicklung/qwikinow.grafana.net MCP - modac-dev-mcp/password",
         "OBAN_AUTH_TOKEN": "op://Entwicklung/Oban Pro/credential",


### PR DESCRIPTION
Ein neuer Eintrag in `op_secrets_tpl`, nach dem Muster von `FONTAWESOME_NEXUS_AUTH_TOKEN`:

| ENV | 1Password-Referenz |
|---|---|
| `PKG_READER_NEXUS_AUTH_IDENT` | `op://Entwicklung/nexus-user-pkg-reader/npm-auth-ident` |

Der Wert ist ein vollständiges `user:password`-Paar, kein Token — Yarns `npmAuthIdent` macht das Base64 selbst. Das Lese-Credential gehört auf jede Dev-Maschine, ohne es läuft kein `yarn install` gegen die neue Registry.

**Vault:** bewusst `Entwicklung` (nicht `Entwicklung Sensitiv`), das Item wurde dorthin verschoben. `setupenvs` validiert jede Referenz per `op read` und bricht die **gesamte** Provisionierung ab, wenn eine nicht auflösbar ist (`setupenvs.go:125-128`) — eine Referenz auf einen nicht überall lesbaren Vault würde `machine provision` teamweit kaputt machen. Die Referenz ist verifiziert auflösbar.

**Bestehende Entwickler:** die Merge-Schleife (`setupenvs.go:84-88`) fügt nur Keys hinzu, die im lokalen `devbox.json` fehlen. Wer den Key lokal schon mit anderem Wert gesetzt hat, behält ihn und muss per `machine edit-config` nachziehen.

**Rollout:** Machine-Hash absichtlich nicht gebumpt (macht `update-machine-hash.yml` auf `main`). Die Änderung greift erst danach und nach erneutem `machine provision`.

**Nicht Teil des PRs:**
- `NPM_PUBLISHER_NEXUS_AUTH_IDENT` (Publish-Rechte auf `npm-private-hosted`) — bewusst nicht maschinenweit verteilt. Wer publishen muss, holt das Credential separat, z. B. repo-lokal über `op run --env-file .op-envs`.
- `NPM_MODAC_CLOUD_AUTH_TOKEN` (alte Registry, nach dem Cutover als Folgeschritt prüfen).
- `.op-envs` in QwikiContrib (deckt bewusst den Repo-lokalen Fall ab).
